### PR TITLE
Expand hint count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 ### Enhancements
+* Add `meow-expand-hint-count`.
 * Add more defaults to `meow-mode-state-list`.
 * improve color calculation in bmacro
 * support change char in bmacro (as the fallback behaviour for change, by default)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Master (Unreleased)
 
 ### Enhancements
-* Add `meow-expand-hint-count`.
+* Add `meow-expand-hint-counts`.
 * Add more defaults to `meow-mode-state-list`.
 * improve color calculation in bmacro
 * support change char in bmacro (as the fallback behaviour for change, by default)

--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -79,7 +79,7 @@ A list of major modes where expand feature should be disabled.
 The expand feature use ~overlay~ for display,
 and it may not work well with texts with inconsistent sizes.
 
-** meow-expand-hint-count
+** meow-expand-hint-counts
 
 Default:
 #+begin_src emacs-lisp

--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -79,6 +79,25 @@ A list of major modes where expand feature should be disabled.
 The expand feature use ~overlay~ for display,
 and it may not work well with texts with inconsistent sizes.
 
+** meow-expand-hint-count
+
+Default:
+#+begin_src emacs-lisp
+  ((word . 30)
+   (line . 30)
+   (block . 30)
+   (find . 30)
+   (till . 30))
+#+end_src
+
+The maximum numbers for expand hints of each type.
+
+** meow-expand-hint-remove-delay
+
+Default: 1.0
+
+The delay before the position hint disappears.
+
 ** meow-selection-command-fallback
 
 Default:

--- a/meow-var.el
+++ b/meow-var.el
@@ -82,6 +82,16 @@ This will affect how selection is displayed."
   :group 'meow
   :type 'integer)
 
+(defcustom meow-expand-hint-count
+  '((word . 30)
+    (line . 30)
+    (block . 30)
+    (find . 30)
+    (till . 30))
+  "The maximum numbers for expand hints of each type."
+  :group 'meow
+  :type 'integer)
+
 (defcustom meow-keypad-message t
   "Whether to log keypad messages in minibuffer."
   :group 'meow

--- a/meow-var.el
+++ b/meow-var.el
@@ -82,7 +82,7 @@ This will affect how selection is displayed."
   :group 'meow
   :type 'integer)
 
-(defcustom meow-expand-hint-count
+(defcustom meow-expand-hint-counts
   '((word . 30)
     (line . 30)
     (block . 30)

--- a/meow-visual.el
+++ b/meow-visual.el
@@ -219,7 +219,7 @@ There is a cache mechanism, if the REGEXP is not changed, we simply inc/dec idx 
   (when (and (meow-normal-mode-p)
              (not (member major-mode meow-expand-exclude-mode-list))
              (meow--select-expandable-p))
-    (let ((num (alist-get (cdr (meow--selection-type)) meow-expand-hint-maximum-numbers)))
+    (let ((num (alist-get (cdr (meow--selection-type)) meow-expand-hint-counts)))
       (meow--highlight-num-positions nav-functions num))))
 
 (provide 'meow-visual)

--- a/meow-visual.el
+++ b/meow-visual.el
@@ -144,39 +144,40 @@ There is a cache mechanism, if the REGEXP is not changed, we simply inc/dec idx 
 
 (defun meow--highlight-num-positions-1 (nav-function faces bound)
   (save-mark-and-excursion
-    (let ((pos (point)))
+    (let ((pos (point))
+          (i 1))
       (cl-loop for face in faces
                do
-               (cl-loop for i from 1 to 10 do
-                        (if-let ((r (funcall nav-function)))
-                            (if (> r 0)
-                                (save-mark-and-excursion
-                                  (goto-char r)
-                                  (if (or (> (point) (cdr bound))
-                                          (< (point) (car bound))
-                                          (= (point) pos))
-                                      (cl-return)
-                                    (setq pos (point))
-                                    (let ((ov (make-overlay (point) (1+ (point))))
-                                          (before-full-width-char (and (char-after) (= 2 (char-width (char-after)))))
-                                          (before-newline (equal 10 (char-after)))
-                                          (before-tab (equal 9 (char-after)))
-                                          (n (if (= i 10) 0 i)))
-                                      (overlay-put ov 'window (selected-window))
-                                      (cond
-                                       (before-full-width-char
-                                        (overlay-put ov 'display (propertize (format "%s" (meow--format-full-width-number n)) 'face face)))
-                                       (before-newline
-                                        (overlay-put ov 'display (concat (propertize (format "%s" n) 'face face) "\n")))
-                                       (before-tab
-                                        (overlay-put ov 'display (concat (propertize (format "%s" n) 'face face) "\t")))
-                                       (t
-                                        (overlay-put ov 'display (propertize (format "%s" n) 'face face))))
-                                      (push ov meow--expand-overlays))))
-                              (cl-return))
-                          (cl-return)))))))
+               (if-let ((r (funcall nav-function)))
+                   (if (> r 0)
+                       (save-mark-and-excursion
+                         (goto-char r)
+                         (if (or (> (point) (cdr bound))
+                                 (< (point) (car bound))
+                                 (= (point) pos))
+                             (cl-return)
+                           (setq pos (point))
+                           (let ((ov (make-overlay (point) (1+ (point))))
+                                 (before-full-width-char (and (char-after) (= 2 (char-width (char-after)))))
+                                 (before-newline (equal 10 (char-after)))
+                                 (before-tab (equal 9 (char-after)))
+                                 (n (mod i 10)))
+                             (overlay-put ov 'window (selected-window))
+                             (cond
+                              (before-full-width-char
+                               (overlay-put ov 'display (propertize (format "%s" (meow--format-full-width-number n)) 'face face)))
+                              (before-newline
+                               (overlay-put ov 'display (concat (propertize (format "%s" n) 'face face) "\n")))
+                              (before-tab
+                               (overlay-put ov 'display (concat (propertize (format "%s" n) 'face face) "\t")))
+                              (t
+                               (overlay-put ov 'display (propertize (format "%s" n) 'face face))))
+                             (push ov meow--expand-overlays)
+                             (cl-incf i))))
+                     (cl-return))
+                 (cl-return))))))
 
-(defun meow--highlight-num-positions (&optional nav-functions)
+(defun meow--highlight-num-positions (nav-functions num)
   (when-let ((nav-functions (or nav-functions meow--expand-nav-function)))
     (setq meow--expand-nav-function nav-functions)
     (setq meow--visual-command this-command)
@@ -184,13 +185,16 @@ There is a cache mechanism, if the REGEXP is not changed, we simply inc/dec idx 
     (meow--remove-match-highlights)
     (meow--remove-search-indicator)
     (-let ((bound (cons (window-start) (window-end)))
-           (faces (if (meow--direction-backward-p)
-                      '(meow-position-highlight-reverse-number-1
-                        meow-position-highlight-reverse-number-2
-                        meow-position-highlight-reverse-number-3)
-                    '(meow-position-highlight-number-1
-                      meow-position-highlight-number-2
-                      meow-position-highlight-number-3)))
+           (faces (-take num
+                         (if (meow--direction-backward-p)
+                             (-concat
+                              (make-list 10 'meow-position-highlight-reverse-number-1)
+                              (make-list 10 'meow-position-highlight-reverse-number-2)
+                              (make-list 10 'meow-position-highlight-reverse-number-3))
+                           (-concat
+                            (make-list 10 'meow-position-highlight-number-1)
+                            (make-list 10 'meow-position-highlight-number-2)
+                            (make-list 10 'meow-position-highlight-number-3)))))
            (nav-function (if (meow--direction-backward-p)
                              (car nav-functions)
                            (cdr nav-functions))))
@@ -215,7 +219,8 @@ There is a cache mechanism, if the REGEXP is not changed, we simply inc/dec idx 
   (when (and (meow-normal-mode-p)
              (not (member major-mode meow-expand-exclude-mode-list))
              (meow--select-expandable-p))
-    (meow--highlight-num-positions nav-functions)))
+    (let ((num (alist-get (cdr (meow--selection-type)) meow-expand-hint-maximum-numbers)))
+      (meow--highlight-num-positions nav-functions num))))
 
 (provide 'meow-visual)
 ;;; meow-visual.el ends here


### PR DESCRIPTION
Add variable `meow-expand-hint-count`, controll how many hint overlays will be displayed, for each type of movement.