### PR TITLE
Add meow-describe-thing-at-point command

### DIFF
--- a/COMMANDS.org
+++ b/COMMANDS.org
@@ -283,3 +283,7 @@ Swap secondary selection with current selection.
 *** meow-pop-grab
 
 Pop secondary selection.
+
+*** meow-describe-thing-at-point
+
+Look up for help for thing at point

--- a/meow-command.el
+++ b/meow-command.el
@@ -1527,6 +1527,16 @@ This command is a replacement for build-in `kmacro-end-macro'."
           (region-str (buffer-substring-no-properties rbeg rend)))
      (meow--second-sel-set-string region-str))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; HELP LOOKUP
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun meow-describe-thing-at-point ()
+  "Look up help for thing at point.
+Calls `meow-describe-thing-at-point-funciton'"
+  (interactive)
+  (funcall meow-describe-thing-at-point-funciton))
+
 ;; aliases
 (defalias 'meow-backward-delete 'meow-backspace)
 (defalias 'meow-c-d 'meow-C-d)

--- a/meow-var.el
+++ b/meow-var.el
@@ -87,6 +87,11 @@ This will affect how selection is displayed."
   :group 'meow
   :type 'boolean)
 
+(defcustom meow-describe-thing-at-point-funciton #'woman
+  "Function that used by `meow-describe-thing-at-point'."
+  :group 'meow
+  :type 'function)
+
 (defcustom meow-char-thing-table
   '((?r . round)
     (?s . square)


### PR DESCRIPTION
Here is a "`describe-at-point`" function. It's "inspired" from evils `evil-lookup` command that is usually bound to `K` in evil.
It has `meow-describe-thing-at-point-funciton` variable where you can change which function is called for description lookup. For now it is bound to `woman`, like in evil, I couldn't find a better built-in command, but something like `elisp-slime-nav-describe-elisp-thing-at-point` from [elisp-slime-nav package](https://github.com/purcell/elisp-slime-nav) would be the perfect default option for this.
I tried to do something like:
```
(defcustom meow-describe-thing-at-point-funciton
  #'(lambda () (call-interactively #'describe-symbol))
  "Function that used by `meow-describe-thing-at-point'."
  :group 'meow
  :type 'function)
```
but that looked ugly so I didn't include it.