### PR TITLE
add undo-tree disclaimer for undo in selection command

### DIFF
--- a/COMMANDS.org
+++ b/COMMANDS.org
@@ -262,6 +262,8 @@ Undo. Unlike built-in, this command will always cancel selection.
 
 Undo in current selection.
 
+Users of ~undo-tree~ package must set ~undo-tree-enable-undo-in-region~ to ~t~ to make this command work properly.
+
 *** meow-pop-selection
 
 Pop one selection


### PR DESCRIPTION
This change adds a note into COMMANDS.org about possible undo in selection issue for users of undo-tree package.

The users of popular `undo-tree` package are not able to use `meow-undo-in-selection` in correct way by default. Is is caused by design decision in the `undo-tree`.

Setting `undo-tree-enable-undo-in-region` to `t` corrects the behaviour.

[More info about undo-tree undo-in-region is available here](https://gitlab.com/tsc25/undo-tree/-/blob/master/undo-tree.el#L933)

It is understandable if this is something that we don't want to merge since this is a third-party package issue, but since the package in question is very popular a lot of people can run into this issue.