### PR TITLE
Add meow-excluded-modes to disable meow-mode in specified major-mode

### DIFF
--- a/meow-core.el
+++ b/meow-core.el
@@ -97,7 +97,9 @@ This minor mode is used by meow-global-mode, should not be enabled directly."
 ;;;###autoload
 (define-global-minor-mode meow-global-mode meow-mode
   (lambda ()
-    (unless (minibufferp)
+    (if (or (minibufferp)
+            (memq major-mode meow-excluded-modes))
+        (meow-mode 0)
       (meow-mode 1)))
   :group 'meow
   (if meow-mode

--- a/meow-var.el
+++ b/meow-var.el
@@ -40,6 +40,11 @@ This will affect how selection is displayed."
   :group 'meow
   :type 'boolean)
 
+(defcustom meow-excluded-modes nil
+  "List of major-mode excluded by `meow-global-mode'."
+  :group 'meow
+  :type 'list)
+
 (defcustom meow-expand-exclude-mode-list
   '(markdown-mode org-mode)
   "A list of major modes where after command expand should be disabled."


### PR DESCRIPTION
Thank you for developing and maintaining the awesome package!

I would like to have the ability to disable meow-mode in specified major-modes where meow-mode is not needed, such as Eshell-mode.