### PR TITLE
add keyboard cheat sheets and mention tutor to TUTORIAL.ORG

### DIFF
--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -1,9 +1,23 @@
 #+title: TUTORIAL
 
-Meow is a modal editing with 5 states: NORMAL, INSERT, MOTION, KEYPAD and BEACON.
+* Default Keybindings Cheat Sheet
+
+Check out default keybindings for your keyboard layout:
+
+[[https://github.com/meow-edit/meow/blob/master/KEYBINDING_QWERTY.org][QWERTY]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_DVORAK.org][DVORAK]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_DVP.org][PROGRAMMER DVORAK]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_COLEMAK.org][COLEMAK]]
+
+You can very easily change any of these when you setup Meow.
+
+* Tutor inside Emacs
+
+There is a tutor inside Emacs. Open it with ~M-x meow-tutor~.
+
+* States
+
+Meow's modal editing has 5 states: NORMAL, INSERT, MOTION, KEYPAD and BEACON.
 In this tutorial, we will walk through these states and basic operations.
 
-* INSERT
+** INSERT
 
 You can switch to INSERT state with ~meow-insert/append/change/open-below/open-above~.
 
@@ -13,7 +27,7 @@ NOTE:
 
 If you enter INSERT state by ~meow-change~, the inserted content will be selected when you exit.
 
-* NORMAL
+** NORMAL
 
 NORMAL state is the default state for text editing.
 
@@ -21,7 +35,7 @@ For commands in NORMAL state is defined via ~meow-normal-define-key~.
 
 [[file:COMMANDS.org][Check here for command documents]]
 
-* MOTION
+** MOTION
 
 MOTION state is the default state for special modes, like ~dired~, ~proced~, etc.
 
@@ -53,7 +67,7 @@ Now you have swapped ~j~ and ~n~.
 
 The settings we made has nothing to do with the name of a command. Thus, it works in all special modes.
 
-* KEYPAD
+** KEYPAD
 
 KEYPAD is the state used for executing commands without modifier keys.
 
@@ -78,7 +92,7 @@ For example, to execute ~C-M-x C-a M-b c d~, press ~g x a m b SPC c SPC d~, or m
 
 After command execution, no matter succeed or failed, KEYPAD state will be disabled.
 
-* BEACON
+** BEACON
 
 #+begin_quote
 BEACON - Batch KMacro

--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -1,8 +1,8 @@
 #+title: TUTORIAL
 
-* Default Keybindings Cheat Sheet
+* Keybindings Cheat Sheet
 
-Check out default keybindings for your keyboard layout:
+We have created some recommended configs for specific keyboard layouts that you can re-use for a quick setup.
 
 [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_QWERTY.org][QWERTY]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_DVORAK.org][DVORAK]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_DVP.org][PROGRAMMER DVORAK]] - [[https://github.com/meow-edit/meow/blob/master/KEYBINDING_COLEMAK.org][COLEMAK]]
 
@@ -10,7 +10,7 @@ You can very easily change any of these when you setup Meow.
 
 * Tutor inside Emacs
 
-There is a tutor inside Emacs. Open it with ~M-x meow-tutor~.
+There is a tutor inside Emacs after installing Meow. Open it with ~M-x meow-tutor~.
 
 * States
 


### PR DESCRIPTION
Meow was quickly mentioned in the [latest System Crafters stream](https://youtu.be/7E-6j6VTZgM?t=1122)! David (from System Crafters) after reading the description, he clicked on Tutorial link under Documents section. I got the feeling that section is a bit misleading because people expect to learn more about keybindings as well.

I think we should at very top of Tutorial section add links to all the keyboard layout cheatsheets. So people who skipped 'Getting started' section (because they we curious how Meow works before installing) can still get the information they need and not get discouraged from using Meow.

What do you think?