### PR TITLE
add mode and meow state specific keymaps

### DIFF
--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -17,6 +17,18 @@ Define key in NORMAL state.
    ...)
 #+end_src
 
+** meow-state-define-key
+
+Bind =keys= under =keymap= when running in meow =state=. Both =keymap= and =state= can be either a quoted list or single quoted item.
+
+The keys bound here are found through =emulation-mode-map-alists= and so have a higher precedence than the specified =keymap=. See the elisp manual on [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Searching-Keymaps.html][Searching Keymaps]] for more information on keymap order.
+
+Example:
+#+begin_src emacs-lisp
+  (meow-state-define-key 'emacs-lisp-mode-map 'insert
+    '("C-z" . eval-last-sexp))
+#+end_src
+
 ** meow-leader-define-key
 
 Like ~meow-normal-define-key~, but for leader keymap.

--- a/meow-core.el
+++ b/meow-core.el
@@ -27,6 +27,7 @@
 
 (require 'meow-util)
 (require 'meow-command)
+(require 'meow-keymap)
 (require 'meow-keypad)
 (require 'meow-var)
 (require 'meow-esc)
@@ -172,7 +173,9 @@ then SPC will be bound to LEADER."
   (when (meow--init-motion-p)
     (meow-normal-mode -1)
     (meow--save-origin-commands)
-    (meow-motion-mode 1)))
+    (meow-motion-mode 1))
+  ;; ensure user overlay keymaps are initialized
+  (meow-activate-overlay-maps))
 
 (defun meow--disable ()
   "Disable Meow."
@@ -203,6 +206,9 @@ then SPC will be bound to LEADER."
                        `((meow-keypad-mode . ,meow-keypad-state-keymap)))
   (add-to-ordered-list 'emulation-mode-map-alists
                        `((meow-beacon-mode . ,meow-beacon-state-keymap)))
+  (add-to-ordered-list 'emulation-mode-map-alists
+                       'meow--user-overlay-maps)
+  (add-hook 'meow-switch-state-hook #'meow-activate-overlay-maps)
   (when meow-use-cursor-position-hack
     (setq redisplay-highlight-region-function #'meow--redisplay-highlight-region-function)
     (setq redisplay-unhighlight-region-function #'meow--redisplay-unhighlight-region-function))
@@ -221,6 +227,10 @@ then SPC will be bound to LEADER."
   (remove-hook 'kill-emacs-hook 'meow--on-exit)
   (meow--disable-shims)
   (meow--remove-modeline-indicator)
+  ;; remove meow overlay keymaps
+  (setq emulation-mode-map-alists
+        (delq 'meow--user-overlay-maps emulation-mode-map-alists))
+  (remove-hook 'meow-switch-state-hook #'meow-activate-overlay-maps)
   (when meow-use-cursor-position-hack
     (setq redisplay-highlight-region-function meow--backup-redisplay-highlight-region-function)
     (setq redisplay-unhighlight-region-function meow--backup-redisplay-unhighlight-region-function))

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -22,6 +22,7 @@
 ;; Define custom keys in normal map with function `meow-normal-define-key'.
 ;; Define custom keys in global leader map with function `meow-leader-define-key'.
 ;; Define custom keys in leader map for specific mode with function `meow-leader-define-mode-key'.
+;; Define custom keys for specific meow state and specific mode `meow-state-define-key'.
 
 ;;; Code:
 
@@ -66,6 +67,26 @@ Optional argument ARGS key definitions."
         args)
   (cl-loop for arg in args do
            (add-to-list 'meow--motion-overwrite-keys (car arg))))
+
+(defun meow-state-define-key (keymaps states &rest args)
+  "Define keys under KEYMAPS for STATES. KEYMAPS can either be a quoted keymap
+or a list of quoted keymaps. STATES can either be a quoted meow state or a
+list of quoted meow states.
+
+Usage:
+  (meow-state-define-key 'org-mode-map 'insert
+    '(\"TAB\" . company-expand))
+  (meow-state-define-key '(prog-mode-map org-mode-map) '(normal insert)
+    '(\"Q\" . keyboard-quit))"
+  (declare (indent 2))
+  (dolist (state (if (listp states) states (list states)))
+    (dolist (keymap-sym (if (listp keymaps) keymaps (list keymaps)))
+      (let* ((keymap (symbol-value keymap-sym))
+             (overlay-map (meow--get-overlay-map keymap state t)))
+        (dolist (key-def args)
+          (define-key overlay-map
+            (kbd (car key-def))
+            (meow--parse-def (cdr key-def))))))))
 
 (defun meow-setup-line-number ()
   (add-hook 'display-line-numbers-mode-hook #'meow--toggle-relative-line-number)


### PR DESCRIPTION
I would like to propose adding meow state specific and mode specific keybinds. So keybinds that would only be active under a specified mode (major or minor) and when under a specific meow state. This would allow binds in any combination of mode and meow state to be active and play nicely with one another.

My thought was to use `emulation-mode-map-alists` (similar to meow state's minor modes) to accomplish this. For lack of a better name I chose to call these keymaps "overlay maps", let me copy and paste some documentation going over their implementation:

```
;;; Overlay Maps
;; An "overlay map" is a keymap that should be activated when running under a
;; specific mode (major or minor) and meow state. A keymap is considered an
;; overlay when the vector [meow-overlay] is set as a key in the map. These
;; overlay maps are stored in the mode's keymap under the key
;; [meow-X-state] where X is the meow state. Ex. [meow-insert-state].
;;
;; During setup we add the symbol `meow--user-overlay-maps' to
;; `emulation-mode-map-alists' to facilitate our overlay maps.
;;
;; When meow changes state the following occurs:
;; 1. we look through all active keymaps for any overlay maps.
;; 2. all such overlay maps are combined into a single keymap with
;;    `make-composed-keymap'.
;; 3. we ensure the combined map is accessible under `emulation-mode-map-alists'
;;    by adding a mapping of meow minor mode to keymap to the alist
;;    `meow--user-overlay-maps'.
```

An example:
```
(meow-state-define-key 'org-mode-map 'normal
  "S-<left>"    'org-promote-subtree
  "S-<up>"      'org-move-subtree-up
  "S-<down>"    'org-move-subtree-down
  "S-<right>"   'org-demote-subtree
  "C-S-<left>"  'org-do-promote
  "C-S-<right>" 'org-do-demote
  )
```

Thoughts?