### PR TITLE
Helper function to create prefix keys for leader commands

### DIFF
--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -31,6 +31,31 @@
 (require 'meow-var)
 (require 'meow-keymap)
 
+(defmacro meow--define-keymap-prefix (parent-keymap key name)
+  "Create prefix KEY for PARENT-KEYMAP with NAME."
+  (let ((keymap-name (make-symbol (concat name "-keymap")))
+        (alias-name (make-symbol name)))
+    `(progn
+       (defvar ,keymap-name (make-sparse-keymap))
+       (defalias ',alias-name ,keymap-name)
+       (define-key ,parent-keymap (kbd ,key) ',alias-name))))
+
+(defun meow-leader-define-prefix (key name)
+  "Define key prefix for leader.
+
+Defines KEY as a prefix which can be used in `meow-leader-define-key`.
+NAME is a valid symbol name which is also displayed in which-key popup.
+
+Usage:
+    (meow-leader-define-prefix \"g\" \"my-git\")
+
+    (meow-leader-define-key
+     '(\"gs\" . magit-status)
+     '(\"gb\" . magit-blame)
+     '(\"gg\" . magit-dispatch))
+"
+  (eval (macroexpand `(meow--define-keymap-prefix meow-leader-keymap ,key ,name))))
+
 (defun meow-leader-define-key (&rest args)
   "Define key for Leader.
 


### PR DESCRIPTION
I am kinda new to Emacs lisp, and I had a hard time figuring out how to add new prefixes to the leader key. `(error "Key sequence z s starts with non-prefix key z")` didn't help much, but enough that I could find my way to write a helper function.

I think it can be useful for others as well. Please take a look. If you think it can be an acceptable addition to the repo and want me to make some changes, I'll be very happy to do that.

Thank you for your work on this project.