### PR TITLE
fix meow--enable to avoid executing symbol-name w.r.t lambda func.

### DIFF
--- a/meow-core.el
+++ b/meow-core.el
@@ -201,6 +201,7 @@ an init function."
               (cmd (key-binding "a")))
           (and
            (commandp cmd)
+           (symbolp cmd)
            (string-match-p "\\`.*self-insert.*\\'" (symbol-name cmd)))))
       (meow-normal-mode 1))
 


### PR DESCRIPTION
In `meow--enable`, it checks whether "self-insert" is assigned to key "a" or not by using `symbol-name`.
However, an error occurs when key "a" is assigned to a lambda function, such as neotree.
To avoid this problem, the assigned function is checked for symbol before `symbol-name` is executed.