### PR TITLE
Fix beacon symbol returned in meow--current-state

### DIFF
--- a/meow-util.el
+++ b/meow-util.el
@@ -167,7 +167,7 @@ For performance reasons, we save current cursor type to
    ((bound-and-true-p meow-normal-mode) 'normal)
    ((bound-and-true-p meow-motion-mode) 'motion)
    ((bound-and-true-p meow-keypad-mode) 'keypad)
-   ((bound-and-true-p meow-beacon-mode) 'cursor)))
+   ((bound-and-true-p meow-beacon-mode) 'beacon)))
 
 (defun meow--should-update-display-p ()
   (cl-case meow-update-display-in-macro


### PR DESCRIPTION
If `meow-beacon-mode` is active, then `meow--current-state` will return the symbol `'cursor`. `meow--switch-state` expects the symbol to be `'beacon`. This may be a bug, but I could be wrong since everything seems to work fine. 