### PR TITLE
Meow bind

### DIFF
--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -97,9 +97,7 @@ Check `meow-normal-define-key' for usages."
           (define-key meow-motion-state-keymap
             (kbd (car key-def))
             (meow--parse-def (cdr key-def))))
-        keybinds)
-  (cl-loop for keybind in keybinds do
-           (add-to-list 'meow--motion-overwrite-keys (car keybind))))
+        keybinds))
 
 (defun meow-setup-line-number ()
   (add-hook 'display-line-numbers-mode-hook #'meow--toggle-relative-line-number)

--- a/meow-keymap.el
+++ b/meow-keymap.el
@@ -167,5 +167,14 @@
     map)
   "Keymap for Meow cursor state.")
 
+(defvar meow-keymap-alist
+  `((insert . ,meow-insert-state-keymap)
+    (normal . ,meow-normal-state-keymap)
+    (keypad . ,meow-keypad-state-keymap)
+    (motion . ,meow-motion-state-keymap)
+    (beacon . ,meow-beacon-state-keymap)
+    (leader . ,meow-leader-keymap))
+  "Alist of symbols of state names to keymaps.")
+
 (provide 'meow-keymap)
 ;;; meow-keymap.el ends here

--- a/meow-util.el
+++ b/meow-util.el
@@ -435,9 +435,10 @@ Looks up the state in meow-replace-state-name-list"
 
 (defun meow--save-origin-commands ()
   (setq meow--origin-commands nil)
-  (cl-loop for key in meow--motion-overwrite-keys do
+  (cl-loop for key-code being the key-codes of meow-motion-state-keymap do
            (ignore-errors
-             (let ((cmd (key-binding (kbd key))))
+             (let* ((key (char-to-string key-code))
+                    (cmd (key-binding (kbd key))))
                (when (and (commandp cmd)
                           (not (equal cmd 'undefined)))
                  (let ((rebind-key (concat meow-motion-remap-prefix key)))

--- a/meow-var.el
+++ b/meow-var.el
@@ -260,15 +260,6 @@ For examples:
     ((lambda () t)       . meow--update-cursor-default))
   "Alist of predicates to functions that set cursor type and color.")
 
-(defvar meow-keymap-alist
-  '((insert . meow-insert-state-keymap)
-    (normal . meow-normal-state-keymap)
-    (keypad . meow-keypad-state-keymap)
-    (motion . meow-motion-state-keymap)
-    (beacon . meow-beacon-state-keymap)
-    (leader . meow-leader-keymap))
-  "Alist of symbols of state names to keymaps.")
-
 (defvar meow-keypad-describe-keymap-function 'meow-describe-keymap
   "The function used to describe (KEYMAP) during keypad execution.
 

--- a/meow-var.el
+++ b/meow-var.el
@@ -485,10 +485,6 @@ Has a structure of (sel-type point mark).")
 (defvar meow--keypad-help nil
   "If keypad in help mode.")
 
-(defvar meow--motion-overwrite-keys
-  '("SPC")
-  "A list of keybindings to overwrite in MOTION state.")
-
 (defvar meow--beacon-backup-hl-line
   nil
   "Whether hl-line is enabled by user.")


### PR DESCRIPTION
See https://github.com/meow-edit/meow/pull/158#issuecomment-1007072673. Some comments:

- Removal of `meow--motion-overwrite-keys` should be tested a bit more, I only have the basic qwerty config which seems ok
- Maybe `meow-keymap-alist` should directly map to values and not symbols, and we can get rid of `symbol-value` in `meow-bind`
- I prefer not using `&rest keybinds` - much less quoting
- Documentation needs to be updated if we proceed with this