### PR TITLE
Fix a typo & propose one more candidate for meow-mode-state-list

### DIFF
--- a/meow-tutor.el
+++ b/meow-tutor.el
@@ -364,7 +364,7 @@
      This sentence has incorrect words in it.
 
 =================================================================
-=                         KILL ANK YANK                         =
+=                         KILL AND YANK                         =
 =================================================================
 
  The \\[meow-kill] key also copies the deleted content which can then be

--- a/meow-var.el
+++ b/meow-var.el
@@ -172,6 +172,7 @@ This option will affect the color of position hint and fake region cursor."
     (conf-mode . normal)
     (deadgrep-edit-mode . normal)
     (deft-mode . normal)
+    (diff-mode . normal)
     (ediff-mode . motion)
     (gud-mode . normal)
     (haskell-interactive-mode . normal)


### PR DESCRIPTION
I feel the need to edit *.diff or *.patch files so I suggest binding
NORMAL to diff-mode. But I notice MOTION is the default for
ediff-mode, so change it to MOTION if you think all diff files should
go with MOTION.