### PR TITLE
Add a customizable meow-goto-line-function

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -930,22 +930,12 @@ numeric, repeat times.
   (interactive "p")
   (meow-line n t))
 
-(defun meow-goto-line (arg)
+(defun meow-goto-line ()
   "Goto line, recenter and select that line."
-  (interactive "P")
-  (let (beg
-        end
-        (ln (when arg (prefix-numeric-value arg))))
-    (save-mark-and-excursion
-      (while (not ln)
-        (let* ((input (read-from-minibuffer "Goto line: ")))
-          (if (string-match-p "[[:digit:]]+" input)
-              (setq ln (string-to-number input))
-            (message "please enter a number."))))
-      (goto-char (point-min))
-      (forward-line (1- ln))
-      (setq beg (line-beginning-position)
-            end (line-end-position)))
+  (interactive)
+  (call-interactively meow-goto-line-function)
+  (let ((beg (line-beginning-position))
+        (end (line-end-position)))
     (thread-first
       (meow--make-selection '(expand . line) beg end nil)
       (meow--select))

--- a/meow-var.el
+++ b/meow-var.el
@@ -247,6 +247,11 @@ For examples:
   :group 'meow
   :type 'string)
 
+(defcustom meow-goto-line-function 'goto-line
+  "Function to use in `meow-goto-line'."
+  :group 'meow
+  :type 'function)
+
 (defvar meow-state-mode-alist
   '((normal . meow-normal-mode)
     (insert . meow-insert-mode)


### PR DESCRIPTION
I added this to be able to do: `(setq meow-goto-line-function 'consult-goto-line)`.

I also noticed `meow-goto-line` has two bindings in KEYBINDING_QWERTY.org:
```
(meow-normal-define-key
   ...
   '("Q" . meow-goto-line)
   '("X" . meow-goto-line)
```
Do you plan to keep both?