### PR TITLE
Allow better customization of meow-keypad-start-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Master (Unreleased)
 
+### Breaking Changes
+
+* [#209](https://github.com/meow-edit/meow/pull/209) Make
+  `meow-keypad-start-keys` an association list to enhance customizability.
+  * If you modify this variable, it may break on the next update. See
+    [CUSTOMIZATIONS](./CUSTOMIZATIONS) for more details.
+
 ## 1.4.2 (2022-03-13)
 
 ### Bugs fixed

--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -174,6 +174,14 @@ Default: ~t~
 
 Whether to log keypad messages in minibuffer.
 
+** meow-keypad-start-keys
+
+Default: ='((?c . ?c) (?h . ?h) (?x . ?x))=
+
+Alist of keys to begin keypad translation. For instance, given the default
+value, pressing "c" in keypad mode will look up it's value in the alist, and
+add "C-c" to the keypad.
+
 ** meow-char-thing-table
 
 Default:

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -193,7 +193,7 @@
                         (not (member key (list meow-keypad-meta-prefix
                                                meow-keypad-ctrl-meta-prefix
                                                meow-keypad-literal-prefix)))
-                        (not (member key meow-keypad-start-keys)))
+                        (not (alist-get key meow-keypad-start-keys)))
                (let ((keys (vector (meow--get-event-key key))))
                  (unless (lookup-key km keys)
                    (define-key km keys (funcall meow-keypad-get-title-function def))))))
@@ -436,8 +436,12 @@ try replacing the last modifier and try again."
              meow--keypad-keys)
         (setq meow--use-literal t))
        ((or meow--keypad-keys
-            (member e meow-keypad-start-keys))
-        (push (cons 'control key) meow--keypad-keys))
+            (alist-get e meow-keypad-start-keys))
+        (push (cons 'control (if meow--keypad-keys
+                                 key
+                               (meow--parse-input-event
+                                (alist-get e meow-keypad-start-keys))))
+              meow--keypad-keys))
        (meow--keypad-allow-quick-dispatch
         (if-let ((keymap (meow--get-leader-keymap)))
             (setq meow--keypad-base-keymap keymap)

--- a/meow-var.el
+++ b/meow-var.el
@@ -243,10 +243,15 @@ Nil stands for taking leader keymap from `meow-keymap-alist'."
   :group 'meow
   :type 'character)
 
-(defcustom meow-keypad-start-keys '(?c ?h ?x)
-  "The keys to start keypad translation."
+(defcustom meow-keypad-start-keys
+  '((?c . ?c)
+    (?h . ?h)
+    (?x . ?x))
+  "Alist of keys to begin keypad translation. When a key char is pressed,
+it's corresponding value is appended to C- and the user is
+prompted to finish the command."
   :group 'meow
-  :type 'list)
+  :type 'alist)
 
 (defcustom meow-motion-remap-prefix "H-"
   "The prefix string used when remapping an occupied key in MOTION state.


### PR DESCRIPTION
Currently, there is no good way to have say, `u` in leader correspond to `C-c`. 

In this patch, meow-keypad-start-keys becomes an alist of keys to keys instead of a list. This is of course a breaking change, but I don't think that it will affect many people since the variable isn't actually documented. 

In general, I think this is a bit of a hack to avoid the real issue which is that keypad code is not very abstracted (meta and ctrl key variables need to be set individually, and so on) but I don't think it's worth potentially introducing some bigger more breaking changes.