### PR TITLE
add meow-duplicate and duplicate-and-comment

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -212,6 +212,28 @@ This command supports `meow-selection-command-fallback'."
   (when (meow--allow-modify-p)
     (meow--execute-kbd-macro meow--kbd-yank-pop)))
 
+(defun meow-duplicate ()
+  "Duplicate region if active. Otherwise duplicate char at point"
+  (interactive)
+  (if (region-active-p)
+      (progn
+        (meow-save)
+        (meow-yank))
+    (progn
+      (meow-save-char)
+      (meow-yank))))
+
+(defun meow-duplicate-and-comment ()
+  "Duplicate region and then comment or uncomment region"
+  (interactive)
+  (if (region-active-p)
+      (progn
+        (meow-save)
+        (meow-yank)
+        (comment-or-uncomment-region
+         (region-beginning)
+         (region-end)))))
+
 ;;; Quit
 
 (defun meow-cancel-selection ()


### PR DESCRIPTION
I have written a rudimentary pair of duplication functions that basically save and then yank. 

This is basically like `crux-duplicate-current-line-or-region` from crux, but implemented with meow functions instead. I have found this very useful after I wrote it for myself.

The current duplicate function duplicates a char instead of a line like crux when no region is active. I think this makes sense because selecting a line is natural and common but selecting a char is more awkward (expand right).

I think this is a good candidate for `P` in suggested keybindings which is currently free [not in commit (yet)]

Any thoughts on this?