### PR TITLE
Any state as initial state (meow-mode-state-list)

### DIFF
--- a/meow-core.el
+++ b/meow-core.el
@@ -138,22 +138,19 @@ Note: When this function is called, NORMAL state is already enabled.
 NORMAL state is enabled globally when `meow-global-mode' is used.
 because in `fundamental-mode', there's no chance for meow to call
 an init function."
-  (let ((state (meow--mode-get-state)))
+  (let ((state (meow--mode-get-state))
+        (motion (lambda ()
+                  (meow--disable-current-state)
+                  (meow--save-origin-commands)
+                  (meow-motion-mode 1))))
     (cond
      ;; if MOTION is specified
      ((eq state 'motion)
-      (meow-normal-mode -1)
-      (setq meow--current-state nil)
-      (meow--save-origin-commands)
-      (meow-motion-mode 1))
-
-     ;; if NORMAL is specified
-     ((eq state 'normal)
-      nil)
+      (funcall motion))
 
      (state
-      (meow-normal-mode -1)
-      (funcall (meow-intern (symbol-name state) "-mode") 1))
+      (meow--disable-current-state)
+      (meow--switch-state state t))
 
      ;; if key A is bound to a self-insert command
      ((progn

--- a/meow-core.el
+++ b/meow-core.el
@@ -138,18 +138,22 @@ Note: When this function is called, NORMAL state is already enabled.
 NORMAL state is enabled globally when `meow-global-mode' is used.
 because in `fundamental-mode', there's no chance for meow to call
 an init function."
-  (let ((state-to-modes (seq-group-by #'cdr meow-mode-state-list)))
+  (let ((state (meow--mode-get-state)))
     (cond
      ;; if MOTION is specified
-     ((apply #'derived-mode-p (mapcar #'car (alist-get 'motion state-to-modes)))
+     ((eq state 'motion)
       (meow-normal-mode -1)
       (setq meow--current-state nil)
       (meow--save-origin-commands)
       (meow-motion-mode 1))
 
      ;; if NORMAL is specified
-     ((apply #'derived-mode-p (mapcar #'car (alist-get 'normal state-to-modes)))
+     ((eq state 'normal)
       nil)
+
+     (state
+      (meow-normal-mode -1)
+      (funcall (meow-intern (symbol-name state) "-mode") 1))
 
      ;; if key A is bound to a self-insert command
      ((progn

--- a/meow-core.el
+++ b/meow-core.el
@@ -150,19 +150,7 @@ an init function."
 
      (state
       (meow--disable-current-state)
-      (meow--switch-state state t))
-
-     ;; if key A is bound to a self-insert command
-     ((progn
-        ;; Disable meow-normal-mode, we need test the command name bound to a single letter key.
-        (meow-normal-mode -1)
-        (setq meow--current-state nil)
-        (let ((cmd (key-binding "a")))
-          (and
-           (commandp cmd)
-           (symbolp cmd)
-           (string-match-p "\\`.*self-insert.*\\'" (symbol-name cmd)))))
-      (meow-normal-mode 1)))))
+      (meow--switch-state state t)))))
 
 (defun meow--disable ()
   "Disable Meow."

--- a/meow-core.el
+++ b/meow-core.el
@@ -165,12 +165,7 @@ an init function."
            (commandp cmd)
            (symbolp cmd)
            (string-match-p "\\`.*self-insert.*\\'" (symbol-name cmd)))))
-      (meow-normal-mode 1))
-
-     ;; fallback to MOTION state
-     (t
-      (meow--save-origin-commands)
-      (meow-motion-mode 1)))))
+      (meow-normal-mode 1)))))
 
 (defun meow--disable ()
   "Disable Meow."

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -228,12 +228,13 @@ This function produces several items:
 
 (defun meow--mode-get-state ()
   "Get initial state for current major mode."
-  (catch 'result
-    (let ((mode major-mode))
-      (while mode
-        (let ((state (alist-get mode meow-mode-state-list)))
-          (if state (throw 'result state)
-            (setq mode (get mode 'derived-mode-parent))))))))
+  (let* ((mode (if mode mode major-mode))
+         (parent-mode (get mode 'derived-mode-parent))
+         (state (alist-get mode meow-mode-state-list)))
+    (cond
+     (state state)
+     (parent (meow--mode-get-state parent-mode))
+     (t 'normal))))
 
 (provide 'meow-helpers)
 ;;; meow-helpers.el ends here

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -226,5 +226,18 @@ This function produces several items:
 					    "meow--update-cursor")
 			    ,keymap))))
 
+(defun meow--mode-get-state ()
+  "Get initial state for current major mode."
+  (let ((modes (alist-get nil
+                          (seq-group-by (lambda (mode)
+                                          (null (derived-mode-p (car mode))))
+                                        meow-mode-state-list)))
+        (mode major-mode))
+    (catch 'result
+      (while mode
+        (let ((state (alist-get mode modes)))
+          (if state (throw 'result state)
+            (setq mode (get mode 'derived-mode-parent))))))))
+
 (provide 'meow-helpers)
 ;;; meow-helpers.el ends here

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -228,8 +228,8 @@ This function produces several items:
 
 (defun meow--mode-get-state ()
   "Get initial state for current major mode."
-  (let ((mode major-mode))
-    (catch 'result
+  (catch 'result
+    (let ((mode major-mode))
       (while mode
         (let ((state (alist-get mode meow-mode-state-list)))
           (if state (throw 'result state)

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -234,7 +234,7 @@ This function produces several items:
     (cond
      (state state)
      (parent (meow--mode-get-state parent-mode))
-     (t 'normal))))
+     (t 'motion))))
 
 (provide 'meow-helpers)
 ;;; meow-helpers.el ends here

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -228,14 +228,10 @@ This function produces several items:
 
 (defun meow--mode-get-state ()
   "Get initial state for current major mode."
-  (let ((modes (alist-get nil
-                          (seq-group-by (lambda (mode)
-                                          (null (derived-mode-p (car mode))))
-                                        meow-mode-state-list)))
-        (mode major-mode))
+  (let ((mode major-mode))
     (catch 'result
       (while mode
-        (let ((state (alist-get mode modes)))
+        (let ((state (alist-get mode meow-mode-state-list)))
           (if state (throw 'result state)
             (setq mode (get mode 'derived-mode-parent))))))))
 

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -226,14 +226,14 @@ This function produces several items:
 					    "meow--update-cursor")
 			    ,keymap))))
 
-(defun meow--mode-get-state ()
+(defun meow--mode-get-state (&optional mode)
   "Get initial state for current major mode."
   (let* ((mode (if mode mode major-mode))
          (parent-mode (get mode 'derived-mode-parent))
          (state (alist-get mode meow-mode-state-list)))
     (cond
      (state state)
-     (parent (meow--mode-get-state parent-mode))
+     (parent-mode (meow--mode-get-state parent-mode))
      (t 'motion))))
 
 (provide 'meow-helpers)

--- a/meow-util.el
+++ b/meow-util.el
@@ -192,12 +192,13 @@ Looks up the state in meow-replace-state-name-list"
     (meow--update-indicator)
     (meow--update-cursor)))
 
-(defun meow--switch-state (state)
-  "Switch to STATE."
+(defun meow--switch-state (state &optional no-hook)
+  "Switch to STATE execute 'meow-switch-state-hook unless NO-HOOK is non-nil."
   (unless (eq state (meow--current-state))
     (let ((mode (alist-get state meow-state-mode-alist)))
       (funcall mode 1))
-    (run-hook-with-args 'meow-switch-state-hook state)))
+    (unless (bound-and-true-p no-hook)
+      (run-hook-with-args 'meow-switch-state-hook state))))
 
 (defun meow--exit-keypad-state ()
   "Exit keypad state."


### PR DESCRIPTION
In some modes I want to start in insert state (shell-mode, eshell-mode, ...). Instead of adding just insert-mode this allows insert-mode and any custom state to be defined as the initial state in a given mode.