### PR TITLE
Fix meow-open-above

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -466,7 +466,7 @@ This command supports `meow-selection-command-fallback'."
       (newline))
     ;; (save-mark-and-excursion
     ;;   (insert "\n"))
-    (indent-for-tab-command)))
+    (indent-according-to-mode)))
 
 (defun meow-open-below ()
   "Open a newline below and switch to INSERT state."
@@ -1597,7 +1597,7 @@ This command is a replacement for build-in `kmacro-end-macro'."
   (if (region-active-p)
       (secondary-selection-from-region)
     (delete-overlay mouse-secondary-overlay)
-	(setq mouse-secondary-start (make-marker))
+    (setq mouse-secondary-start (make-marker))
     (move-marker mouse-secondary-start (point)))
   (meow--cancel-selection))
 


### PR DESCRIPTION
When you have `tab-always-indent` set to `'complete` then there is a bug where `meow-open-above` sometimes tries to complete at point, so this is a fix for that.  