### PR TITLE
fix #246 bug in rendering indicator faces

### DIFF
--- a/meow-util.el
+++ b/meow-util.el
@@ -158,14 +158,20 @@ in the list will always evaluate to true."
 Looks up the state in meow-replace-state-name-list"
   (alist-get state meow-replace-state-name-list))
 
+(defun meow--get-state-face (state)
+  "Get the face of the current STATE."
+  (alist-get state meow-state-face-alist))
+
 (defun meow--render-indicator ()
   "Renders a short indicator based on the current state."
   (when (bound-and-true-p meow-global-mode)
-    (let ((state-name (meow--get-state-name (meow--current-state))))
+    (let* ((state (meow--current-state))
+           (state-name (meow--get-state-name state))
+           (state-face (meow--get-state-face state)))
       (if state-name
           (propertize
            (format " %s " state-name)
-           'face 'meow-insert-indicator)
+           'face state-face)
         ""))))
 
 (defun meow--update-indicator ()

--- a/meow-var.el
+++ b/meow-var.el
@@ -286,6 +286,14 @@ Nil means find the command by key binding."
     (beacon . meow-beacon-mode))
   "Alist of meow states -> modes")
 
+(defvar meow-state-face-alist
+  '((normal . meow-normal-indicator)
+    (insert . meow-insert-indicator)
+    (keypad . meow-keypad-indicator)
+    (motion . meow-motion-indicator)
+    (beacon . meow-beacon-indicator))
+  "Alist of meow states -> faces")
+
 (defvar meow-update-cursor-functions-alist
   '((meow--cursor-null-p . meow--update-cursor-default)
     (minibufferp         . meow--update-cursor-default)


### PR DESCRIPTION
Rendering indicator with corresponding faces rather than `meow-insert-indicator `always