### PR TITLE
(cursor pos hack) fix append behavior at end of line

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -447,7 +447,7 @@ This command supports `meow-selection-command-fallback'."
         (meow--switch-state 'motion))
     (if (not (region-active-p))
         (when (and meow-use-cursor-position-hack
-                   (< (point) (point-max)))
+                   (< (point) (line-end-position)))
           (forward-char 1))
       (meow--direction-forward)
       (meow--cancel-selection))


### PR DESCRIPTION
Currently, when using `meow-use-cursor-position-hack`, when the cursor is at the end of a line and there is no selection, pressing `meow-append` will cause the cursor to go to the beginning of the next line.
This fix makes it so that we stay on the same line (basically, we do the same thing as `meow-insert` here). 