### PR TITLE
Remove needless declare-function

### DIFF
--- a/meow-util.el
+++ b/meow-util.el
@@ -46,7 +46,6 @@
 (declare-function meow--keypad-format-keys "meow-keypad")
 (declare-function meow--keypad-format-prefix "meow-keypad")
 (declare-function meow-minibuffer-quit "meow-command")
-(declare-function meow--execute-kbd-macro "meow-command")
 
 (defun meow--execute-kbd-macro (kbd-macro)
   "Execute KBD-MACRO."


### PR DESCRIPTION
`melow--execute-kbd-macro` is defined in this file. This fixes the following warning.

```
meow-util.el:51:8: Warning: function ‘meow--execute-kbd-macro’ defined
    multiple times in this file
```