### PR TITLE
keep track of direction for no-region cases

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -128,13 +128,12 @@ The direction of selection is MARK -> POS."
   "Just exchange point and mark."
   (interactive)
   (setq meow--backward-p (not meow--backward-p))
-  (if (region-active-p)
-      (progn
-        (exchange-point-and-mark)
-        (if (member last-command
-                    '(meow-visit meow-search meow-mark-symbol meow-mark-word))
-            (meow--highlight-regexp-in-buffer (car regexp-search-ring))
-          (meow--maybe-highlight-num-positions)))))
+  (when (region-active-p)
+    (exchange-point-and-mark)
+    (if (member last-command
+                '(meow-visit meow-search meow-mark-symbol meow-mark-word))
+        (meow--highlight-regexp-in-buffer (car regexp-search-ring))
+      (meow--maybe-highlight-num-positions))))
 
 ;;; Buffer
 

--- a/meow-command.el
+++ b/meow-command.el
@@ -74,7 +74,8 @@ The direction of selection is MARK -> POS."
     (goto-char (if backward mark pos))
     (when sel-type
       (push-mark (if backward pos mark) t t)
-      (setq meow--selection selection))))
+      (setq meow--selection selection))
+    (setq meow--backward-p (meow--direction-backward-p))))
 
 (defun meow--select-without-history (selection)
   "Mark the SELECTION without recording it in `meow--selection-history'."
@@ -93,7 +94,8 @@ The direction of selection is MARK -> POS."
 (defun meow--cancel-selection ()
   "Cancel current selection, clear selection history and deactivate the mark."
   (setq meow--selection-history nil
-        meow--selection nil)
+        meow--selection nil
+        meow--backward-p nil)
   (deactivate-mark t))
 
 (defun meow-undo ()
@@ -123,16 +125,16 @@ The direction of selection is MARK -> POS."
 ;;; exchange mark and point
 
 (defun meow-reverse ()
-  "Just exchange point and mark.
-
-This command supports `meow-selection-command-fallback'."
+  "Just exchange point and mark."
   (interactive)
-  (meow--with-selection-fallback
-   (exchange-point-and-mark)
-   (if (member last-command
-               '(meow-visit meow-search meow-mark-symbol meow-mark-word))
-       (meow--highlight-regexp-in-buffer (car regexp-search-ring))
-     (meow--maybe-highlight-num-positions))))
+  (setq meow--backward-p (not meow--backward-p))
+  (if (region-active-p)
+      (progn
+        (exchange-point-and-mark)
+        (if (member last-command
+                    '(meow-visit meow-search meow-mark-symbol meow-mark-word))
+            (meow--highlight-regexp-in-buffer (car regexp-search-ring))
+          (meow--maybe-highlight-num-positions)))))
 
 ;;; Buffer
 

--- a/meow-util.el
+++ b/meow-util.el
@@ -212,23 +212,25 @@ Looks up the state in meow-replace-state-name-list"
 
 (defun meow--direction-forward ()
   "Make the selection towards forward."
+  (setq meow--backward-p nil)
   (when (and (region-active-p) (< (point) (mark)))
     (exchange-point-and-mark)))
 
 (defun meow--direction-backward ()
   "Make the selection towards backward."
+  (setq meow--backward-p t)
   (when (and (region-active-p) (> (point) (mark)))
     (exchange-point-and-mark)))
 
 (defun meow--direction-backward-p ()
   "Return whether we have a backward selection."
-  (and (region-active-p)
-       (> (mark) (point))))
+  (if (use-region-p)
+      (> (mark) (point))
+    meow--backward-p))
 
 (defun meow--direction-forward-p ()
   "Return whether we have a forward selection."
-  (and (region-active-p)
-       (<= (mark) (point))))
+  (not (meow--direction-backward-p)))
 
 (defun meow--selection-type ()
   "Return current selection type."

--- a/meow-var.el
+++ b/meow-var.el
@@ -483,6 +483,9 @@ Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 
 Has a structure of (sel-type point mark).")
 
+(defvar-local meow--backward-p nil
+  "Direction indicator when there is no region.")
+
 ;;; Hooks
 
 (defvar meow-switch-state-hook nil


### PR DESCRIPTION
Take 2 of fixing the issue where reversing doesn't work with no selection. Previous attempt: #216.

Check the commit message for details. This idea was originally implemented in #272, the code in this pull request extracts the relevant parts.