### PR TITLE
Ensure correct alignment of cheatsheet layout

### DIFF
--- a/meow-cheatsheet.el
+++ b/meow-cheatsheet.el
@@ -134,7 +134,7 @@ Currently `meow-cheatsheet-layout-qwerty', `meow-cheatsheet-layout-dvorak',
       (goto-char (point-max))
       (insert meow--cheatsheet-note)
       (insert (meow--render-cheatsheet-thing-table))
-      (put-text-property (point-min) (point-max) 'display '(height 0.8))
+      (add-face-text-property (point-min) (point-max) 'meow-cheatsheet-command)
       (setq buffer-read-only t))
     (switch-to-buffer buf)))))
 

--- a/meow-face.el
+++ b/meow-face.el
@@ -98,6 +98,14 @@
   "Keypad state cursor."
   :group 'meow)
 
+(defface meow-keypad-cannot-display
+  '((((class color) (background dark))
+     (:height 0.7 :foreground "grey90"))
+    (((class color) (background light))
+     (:height 0.7 :foreground "grey10")))
+  "Face for Meow keypad message when cannot display popup."
+  :group 'meow)
+
 (defface meow-beacon-cursor
   '((((class color) (background dark))
      (:inherit cursor))
@@ -204,18 +212,15 @@
   :group 'meow)
 
 (defface meow-cheatsheet-command
-  '((((class color) (background dark))
-     (:height 0.7 :foreground "grey90"))
-    (((class color) (background light))
-     (:height 0.7 :foreground "grey10")))
+  '((t (:inherit fixed-pitch :height 90)))
   "Face for Meow cheatsheet command."
   :group 'meow)
 
 (defface meow-cheatsheet-highlight
   '((((class color) (background dark))
-     (:foreground "grey90"))
+     (:foreground "grey90" :inherit meow-cheatsheet-command))
     (((class color) (background light))
-     (:foreground "grey10")))
+     (:foreground "grey10" :inherit meow-cheatsheet-command)))
   "Face for Meow cheatsheet highlight text."
   :group 'meow)
 

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -277,7 +277,7 @@
                             def))))
                (meow--string-join " "))))
           (meow--string-join "\n"))
-      (propertize "Frame is too narrow for KEYPAD popup" 'face 'meow-cheatsheet-command))))
+      (propertize "Frame is too narrow for KEYPAD popup" 'face 'meow-keypad-cannot-display))))
 
 
 


### PR DESCRIPTION
* Redefine `meow-cheatsheet-command` face to inherit from `fixed-pitch`
* Update `meow-cheatsheet-highlight` face to inherit from `meow-cheatsheet-command`
* Adjust `meow-cheatsheet` command to set height by face setting
* Create new face for "Frame is too narrow" message issued by `meow--describe-keymap-format`

Discussed in post #339, re issue #340. 