### PR TITLE
Add :meow-state keyword for use-package declarations

### DIFF
--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -358,3 +358,18 @@ change the variable =meow-cursor-type-insert=.
 
 Association list of symbols to their corresponding keymaps. Used
 to generate =meow-*-define-key= helpers.
+
+* Integration to other packages
+** :meow-state use-package keyword
+
+Simple keyword ~:meow-state~ added to [[https://github.com/jwiegley/use-package][use-package]] declarations.  Used to help
+populate ~meow-mode-state-list~, as follows:
+
+#+begin_src emacs-lisp
+(use-package sly
+  :meow-state ((sly-inspector-mode . motion)
+               (sly-db-mode . motion)))
+#+end_src
+
+The above would make the ~sly-inspector~ and ~sly-db~ modes start in Meow's
+~motion~ state.

--- a/meow-shims.el
+++ b/meow-shims.el
@@ -266,6 +266,21 @@ Argument ENABLE non-nil means turn on."
       ;; These vars allow us the select through the polymode chunk
       (add-to-list 'polymode-move-these-vars-from-old-buffer v))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; use-package
+
+(when (fboundp #'use-package)
+  (add-to-list 'use-package-keywords ':meow-state 'append)
+  ;; We re-use the normalize method from :hook.  This way we get the parsing of
+  ;; both a single cons, and a list of several.
+  (defalias 'use-package-normalize/:meow-state #'use-package-normalize/:hook)
+
+  (defun use-package-handler/:meow-state (name-symbol keyword args rest state)
+    (use-package-concat
+     (use-package-process-keywords name-symbol rest state)
+     `(,@(cl-loop for arg in args
+                  collect `(add-to-list 'meow-mode-state-list ',arg))))))
+
 ;; Enable / Disable shims
 
 (defun meow--enable-shims ()


### PR DESCRIPTION
Add simple keyword `:meow-state` added to [use-package](https://github.com/jwiegley/use-package) declarations.  Used to help populate `meow-mode-state-list`, as follows:

```emacs-lisp
(use-package sly
  :meow-state ((sly-inspector-mode . motion)
               (sly-db-mode . motion)))
```

The above would make the `sly-inspector` and `sly-db` modes start in Meow's `motion` state.

Since I know that it's important to the `meow` project to not have any external dependencies, the `meow-use-package` module will only be loaded if `use-package` is installed. I also added a mention in `CUSTOMIZATIONS.org`, so that it's mentioned somewhere in the documentation.  I hope it was the right place to put things.