### PR TITLE
Add meow-grab-next

### DIFF
--- a/meow-beacon.el
+++ b/meow-beacon.el
@@ -37,10 +37,12 @@
 (declare-function meow--selection-fallback "meow-command")
 (declare-function meow--make-selection "meow-command")
 (declare-function meow--select "meow-command")
+(declare-function meow--pop-selection "meow-command")
 (declare-function meow-beacon-mode "meow-core")
 
 (defvar-local meow--beacon-overlays nil)
 (defvar-local meow--beacon-insert-enter-key nil)
+(defvar-local meow--beacon-grab-next-selection nil)
 
 (defun meow--beacon-add-overlay-at-point (pos)
   "Create an overlay to draw a fake cursor as beacon at POS."
@@ -70,6 +72,13 @@ Non-nil BACKWARD means backward direction."
   (unless (or defining-kbd-macro executing-kbd-macro)
     (let ((inside (meow--beacon-inside-secondary-selection)))
       (cond
+       ((eq last-command 'meow-grab-next)
+        (secondary-selection-from-region)
+        (meow--switch-state 'beacon)
+        (setq meow--selection-history meow--beacon-grab-next-selection)
+        (setq meow--beacon-grab-next-selection nil)
+        (meow--pop-selection)
+        (meow--beacon-update-overlays))
        ((and (meow-normal-mode-p)
              inside)
         (meow--switch-state 'beacon)

--- a/meow-command.el
+++ b/meow-command.el
@@ -1582,6 +1582,14 @@ This command is a replacement for built-in `kmacro-end-macro'."
     (meow--cancel-second-selection))
   (meow--cancel-selection))
 
+(defun meow-grab-next ()
+  "Create secondary selection from next command."
+  (interactive)
+  (setq meow--beacon-grab-next-selection
+        (cons (or meow--selection
+                  (meow--make-selection nil (point) (point)))
+              meow--selection-history)))
+
 (defun meow-pop-grab ()
   "Pop to secondary selection."
   (interactive)


### PR DESCRIPTION
I think this is useful if you want to enable secondary selection, but not move point.

For instance, you can now quickly rename a symbol at point in a function via beacons by doing `mark-symbol`, `grab-next`, `bounds-of -thing defun`.