### PR TITLE
In `meow-reverse`, run `C-x C-x` instead of running `exchange-point-and-mark` directly.

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -128,7 +128,7 @@ The direction of selection is MARK -> POS."
 This command supports `meow-selection-command-fallback'."
   (interactive)
   (meow--with-selection-fallback
-   (exchange-point-and-mark)
+   (meow--execute-kbd-macro meow--kbd-exchange-point-and-mark)
    (if (member last-command
                '(meow-visit meow-search meow-mark-symbol meow-mark-word))
        (meow--highlight-regexp-in-buffer (car regexp-search-ring))

--- a/meow-var.el
+++ b/meow-var.el
@@ -392,6 +392,9 @@ Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 (defvar meow--kbd-kill-region "C-w"
   "KBD macro for command `kill-region'.")
 
+(defvar meow--kbd-exchange-point-and-mark "C-x C-x"
+  "KBD macro for command `exchange-point-and-mark'.")
+
 (defvar meow--kbd-back-to-indentation "M-m"
   "KBD macro for command `back-to-indentation'.")
 


### PR DESCRIPTION
- Add `meow--kbd-exchange-point-and-mark` with value "C-x C-x".
- Change `meow-reverse` to run this macro via `meow--execute-kbd-macro`.

This change supports using `rectangle-exchange-point-and-mark` (`C-x C-x`) in `rectangle-mark-mode`.

Suggested in #393.