### PR TITLE
Fix typo in meow-tutor

### DIFF
--- a/meow-tutor.el
+++ b/meow-tutor.el
@@ -350,7 +350,7 @@
 
  --> I like to eat apples since my favorite fruit is apples.
 
- Note: If you want go backward, use \\[negative-argument] as a prefix, there is also
+ Note: If you want to go backwards, use \\[negative-argument] as a prefix; there is also
        a similar command on \\[meow-find], which will jump over that
        character.
 


### PR DESCRIPTION
This repairs typos in meow-tutor, replacing "want go" with "want to go".