### PR TITLE
Add advice `meow--prepare-face` to `enable-theme` instead of `load-theme`

### DIFF
--- a/meow-core.el
+++ b/meow-core.el
@@ -190,7 +190,7 @@ there's no chance for meow to call an init function."
     (setq redisplay-highlight-region-function #'meow--redisplay-highlight-region-function)
     (setq redisplay-unhighlight-region-function #'meow--redisplay-unhighlight-region-function))
   (meow--prepare-face)
-  (advice-add 'load-theme :after 'meow--prepare-face))
+  (advice-add 'enable-theme :after 'meow--prepare-face))
 
 (defun meow--global-disable ()
   "Disable Meow globally."
@@ -210,7 +210,7 @@ there's no chance for meow to call an init function."
     (setq redisplay-unhighlight-region-function meow--backup-redisplay-unhighlight-region-function))
   (unless window-system
     (meow-esc-mode -1))
-  (advice-remove 'load-theme 'meow--prepare-face))
+  (advice-remove 'enable-theme 'meow--prepare-face))
 
 (provide 'meow-core)
 ;;; meow-core.el ends here

--- a/meow-core.el
+++ b/meow-core.el
@@ -160,6 +160,11 @@ there's no chance for meow to call an init function."
   (when (secondary-selection-exist-p)
     (meow--cancel-second-selection)))
 
+(defun meow--enable-theme-advice (theme)
+  "Prepare face if the theme to enable is `user'."
+  (when (eq theme 'user)
+    (meow--prepare-face)))
+
 (defun meow--global-enable ()
   "Enable meow globally."
   (setq-default meow-normal-mode t)
@@ -190,7 +195,7 @@ there's no chance for meow to call an init function."
     (setq redisplay-highlight-region-function #'meow--redisplay-highlight-region-function)
     (setq redisplay-unhighlight-region-function #'meow--redisplay-unhighlight-region-function))
   (meow--prepare-face)
-  (advice-add 'enable-theme :after 'meow--prepare-face))
+  (advice-add 'enable-theme :after 'meow--enable-theme-advice))
 
 (defun meow--global-disable ()
   "Disable Meow globally."
@@ -210,7 +215,7 @@ there's no chance for meow to call an init function."
     (setq redisplay-unhighlight-region-function meow--backup-redisplay-unhighlight-region-function))
   (unless window-system
     (meow-esc-mode -1))
-  (advice-remove 'enable-theme 'meow--prepare-face))
+  (advice-remove 'enable-theme 'meow--enable-theme-advice))
 
 (provide 'meow-core)
 ;;; meow-core.el ends here


### PR DESCRIPTION
This PR resolves #487.

Add advice `meow--prepare-face` to function `enable-theme` instead of `load-theme`. (commit [64bdbee](https://github.com/meow-edit/meow/pull/488/commits/64bdbeed86dc37c981e91be27ea4ad1e8ddb4942)) This will help prepare faces if a theme is enabled with `enable-theme`. The modification does not change the current behavior, because `enable-theme` is called at the end of `load-theme`, and calling `load-theme` also triggers advice on `enable-theme`.

I tested it with the following code:

```emacs-lisp
(push "meow" load-path)
(require 'meow)

(advice-add 'meow--prepare-face
            :before
            (lambda (&rest args)
              (message "call -> %S" (cons 'meow--prepare-face args))))

(defmacro echo-and-eval (sexp)
  (message "eval : %S" sexp)
  (eval sexp))

(my-meow-config)
(echo-and-eval (meow-global-mode 1))
(echo-and-eval (load-theme 'adwaita t))
(echo-and-eval (disable-theme 'adwaita))
(echo-and-eval (enable-theme 'adwaita))
(echo-and-eval (disable-theme 'adwaita))
(echo-and-eval (load-theme 'adwaita t))
(echo-and-eval (disable-theme 'adwaita))
```

and the outputs in \*Message\* buffer are:

```
eval : (meow-global-mode 1)
call -> (meow--prepare-face)
eval : (load-theme 'adwaita t)
call -> (meow--prepare-face user)
call -> (meow--prepare-face adwaita)
eval : (disable-theme 'adwaita)
eval : (enable-theme 'adwaita)
call -> (meow--prepare-face user)
call -> (meow--prepare-face adwaita)
eval : (disable-theme 'adwaita)
eval : (load-theme 'adwaita t)
call -> (meow--prepare-face user)
call -> (meow--prepare-face adwaita)
eval : (disable-theme 'adwaita)
```

The fix looks good. But there is a problem. Every time `enable-theme` is called, `meow--prepare-face` is applied twice: one is for the theme to enable, and another is for the "user" theme. This is because the "user" theme is automatically enabled at the end of the function `enable-theme`.

A simple solution is using a wrapper of `meow--prepare-face` as the advice, which checks the given theme and calls `meow--prepare-face` only when the theme to enable (1st argument of `enable-theme`) is "user". (commit [d933afd](https://github.com/meow-edit/meow/pull/488/commits/d933afd1aec35d4651ccb90a9be947b5e0d824ed))

Running the test code, the outputs in \*Message\* buffer are:

```
eval : (meow-global-mode 1)
call -> (meow--prepare-face)
eval : (load-theme 'adwaita t)
call -> (meow--prepare-face)
eval : (disable-theme 'adwaita)
eval : (enable-theme 'adwaita)
call -> (meow--prepare-face)
eval : (disable-theme 'adwaita)
eval : (load-theme 'adwaita t)
call -> (meow--prepare-face)
eval : (disable-theme 'adwaita)
```

The problem is solved -- `meow--prepare-face` is called only once after `enable-theme`. The cost is an extra defun.