### PR TITLE
Add `meow-replace-pop`.

### DIFF
--- a/meow-var.el
+++ b/meow-var.el
@@ -644,6 +644,28 @@ The value can be nil, quick or record.")
     (meow-backspace . "backspace"))
   "A list of (command . short-name)")
 
+(defcustom meow-replace-pop-command-start-indexes
+  '((meow-replace . 1)
+    (meow-replace-char . 1)
+    (meow-replace-save . 2))
+  "Alist of commands and their starting indices for use by `meow-replace-pop'.
+
+If `meow-replace-pop' is run and the previous command is not
+`meow-replace-pop' or a command which is present in this alist,
+`meow-replace-pop' signals an error."
+  :type '(alist :key-type function :value-type natnum))
+
+(defvar meow--replace-pop-index nil
+  "The index of the previous replacement in the `kill-ring'.
+See also the command `meow-replace-pop'.")
+
+(defvar meow--replace-start-marker (make-marker)
+  "The beginning of the replaced text.
+
+This marker stays before any text inserted at the location, to
+account for any automatic formatting that happens after inserting
+the replacement text.")
+
 ;;; Backup variables
 
 (defvar meow--backup-var-delete-activae-region nil


### PR DESCRIPTION
This command, when run after `meow-replace` or itself, replaces the just inserted text with the next item in the kill ring, without rotating the kill ring.

- Add command `meow-replace`.
- Add variables `meow--replace-pop-index` and `meow--replace-start-marker`.
- Modify commands `meow-replace`, `meow-replace-save`, and `meow-replace-char` to set the marker before inserting the replacement text.

The marker was needed to support `meow-replace-char`, which doesn't use a region. Otherwise, one could use `(mark t)` to get the mark's position.