### PR TITLE
Add beacon remap for meow-change-save

### DIFF
--- a/meow-beacon.el
+++ b/meow-beacon.el
@@ -459,6 +459,19 @@ The recorded kmacro will be applied to all cursors immediately."
    (setq-local meow--beacon-insert-enter-key last-input-event)
    (setq meow--beacon-defining-kbd-macro 'quick)))
 
+(defun meow-beacon-change-save ()
+  "Change and start kmacro recording.
+
+Will terminate recording when exit insert mode.
+The recorded kmacro will be applied to all cursors immediately."
+  (interactive)
+  (meow--with-selection-fallback
+   (meow-beacon-mode -1)
+   (meow-change-save)
+   (call-interactively #'kmacro-start-macro)
+   (setq-local meow--beacon-insert-enter-key last-input-event)
+   (setq meow--beacon-defining-kbd-macro 'quick)))
+
 (defun meow-beacon-change-char ()
   "Change and start kmacro recording.
 

--- a/meow-keymap.el
+++ b/meow-keymap.el
@@ -116,6 +116,7 @@
     (define-key map [remap meow-insert] 'meow-beacon-insert)
     (define-key map [remap meow-append] 'meow-beacon-append)
     (define-key map [remap meow-change] 'meow-beacon-change)
+    (define-key map [remap meow-change-save] 'meow-beacon-change-save)
     (define-key map [remap meow-replace] 'meow-beacon-replace)
     (define-key map [remap meow-kill] 'meow-beacon-kill-delete)
 


### PR DESCRIPTION
In my config, I've switched to using `meow-change-save` over `meow-change`. The former doesn't currently work the same with beacon though, which confused me a bit. I assume it was just an oversight, so this fixes it.