### PR TITLE
Allow custom 'word', 'symbol' definitions

### DIFF
--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -358,3 +358,55 @@ change the variable =meow-cursor-type-insert=.
 
 Association list of symbols to their corresponding keymaps. Used
 to generate =meow-*-define-key= helpers.
+
+** meow-word-thing, meow-symbol-thing
+
+The things used by meow for marking/movement by words and symbols, respectively.
+
+The values are 'things' as understood by ~thingatpt~ - symbols that will be
+passed to ~forward-thing~ and ~bounds-of-thing-at-point~, which see.
+
+This means that they must, at minimum, have a function as the value of their
+=forward-op= symbol property (or the function should be defined as
+~forward-SYMBOLNAME~). This function should accept a single argument, a number
+=n=, and should move over the next =n= things, in either the forward or backward
+direction depending on the sign of =n=. Examples of such functions include
+~forward-word~, ~forward-symbol~ and ~forward-sexp~, which ~thingatpt~ uses for
+the =word=, =symbol= and =sexp= things, respectively.
+
+*** Custom =word=, =symbol= definitions
+
+By customizing these variables, you can make Meow use your own definitions for
+=word= and =symbol=. For example, here is how you can get =word= behavior closer
+to Vim's -
+
+#+begin_src emacs-lisp
+(defun forward-vimlike-word (&optional arg)
+  "Alternate `forward-word'. Essentially the same idea as Vim's 'e'."
+  (interactive "^p")
+  (setq arg (or arg 1))
+  (cl-destructuring-bind (sign move-func char-func)
+      (if (>= arg 0)
+          '(1 skip-syntax-forward char-after)
+        '(-1 skip-syntax-backward char-before))
+    (with-syntax-table (standard-syntax-table)
+      (let ((distance sign))
+        (while (and distance (> (abs distance) 0) (> (* arg sign) 0))
+          (setq distance
+                (when-let ((next-char (funcall char-func))
+                           (next-syntax (char-syntax next-char)))
+                  (cond ((eq next-syntax ?w)
+                         (funcall move-func "w"))
+                        ((eq next-syntax ?\ )
+                         (prog1
+                             (funcall move-func " ")
+                           (forward-vimlike-word sign)))
+                        (t
+                         (funcall move-func "^w ")))))
+          (setq arg (- arg sign)))
+        (and distance (> (abs distance) 0))))))
+
+(put 'vimlike-word 'forward-op #'forward-vimlike-word)
+
+(setq meow-word-thing 'vimlike-word)
+#+end_src

--- a/meow-beacon.el
+++ b/meow-beacon.el
@@ -216,13 +216,13 @@ same way, and escape each time the macro is applied."
           (progn
             (save-mark-and-excursion
               (goto-char (point-min))
-              (while (forward-word 1)
+              (while (forward-thing meow-word-thing 1)
                 (unless (= (point) orig)
                   (meow--beacon-add-overlay-at-point (meow--hack-cursor-pos (point)))))))
 
         (save-mark-and-excursion
           (goto-char (point-max))
-          (while (forward-word -1)
+          (while (forward-thing meow-word-thing -1)
             (unless (= (point) orig)
               (meow--beacon-add-overlay-at-point (point))))))))
   (meow--beacon-shrink-selection))

--- a/meow-beacon.el
+++ b/meow-beacon.el
@@ -216,13 +216,17 @@ same way, and escape each time the macro is applied."
           (progn
             (save-mark-and-excursion
               (goto-char (point-min))
-              (while (forward-thing meow-word-thing 1)
+              (while (let ((p (point)))
+                       (forward-thing meow-word-thing 1)
+                       (not (= p (point))))
                 (unless (= (point) orig)
                   (meow--beacon-add-overlay-at-point (meow--hack-cursor-pos (point)))))))
 
         (save-mark-and-excursion
           (goto-char (point-max))
-          (while (forward-thing meow-word-thing -1)
+          (while (let ((p (point)))
+                       (forward-thing meow-word-thing -1)
+                       (not (= p (point))))
             (unless (= (point) orig)
               (meow--beacon-add-overlay-at-point (point))))))))
   (meow--beacon-shrink-selection))

--- a/meow-thing.el
+++ b/meow-thing.el
@@ -24,7 +24,7 @@
 (require 'meow-util)
 
 (defun meow--bounds-of-symbol ()
-  (when-let (bounds (bounds-of-thing-at-point 'symbol))
+  (when-let (bounds (bounds-of-thing-at-point meow-symbol-thing))
     (let ((beg (car bounds))
           (end (cdr bounds)))
       (save-mark-and-excursion
@@ -56,7 +56,7 @@ The thing `string' is not available in Emacs 27.'"
     (bounds-of-thing-at-point 'string)))
 
 (defun meow--inner-of-symbol ()
-  (bounds-of-thing-at-point 'symbol))
+  (bounds-of-thing-at-point meow-symbol-thing))
 
 (defun meow--bounds-of-string (&optional inner)
   (when-let (bounds (meow--bounds-of-string-1))
@@ -310,7 +310,7 @@ PAIR-EXPR contains two string token lists. The tokens in first
 
 (meow-thing-register 'defun 'defun 'defun)
 
-(meow-thing-register 'symbol #'meow--inner-of-symbol #'meow--bounds-of-symbol)
+(meow-thing-register meow-symbol-thing #'meow--inner-of-symbol #'meow--bounds-of-symbol)
 
 (meow-thing-register 'string #'meow--inner-of-string #'meow--bounds-of-string)
 

--- a/meow-var.el
+++ b/meow-var.el
@@ -136,6 +136,34 @@ This will affect how selection is displayed."
   :type '(alist :key-type (symbol :tag "Command")
                 :key-value (symbol :tag "Direction")))
 
+(defvar meow-word-thing 'word
+  "The \\='thing\\=' used for marking and movement by words.
+
+The values is a \\='thing\\=' as understood by `thingatpt' - a symbol that will
+be passed to `forward-thing' and `bounds-of-thing-at-point', which see.
+
+This means that they must, at minimum, have a function as the value of their
+`forward-op' symbol property (or the function should be defined as
+`forward-SYMBOLNAME'). This function should accept a single argument, a number
+N, and should move over the next N things, in either the forward or backward
+direction depending on the sign of N. Examples of such functions include
+`forward-word', `forward-symbol' and `forward-sexp', which `thingatpt' uses for
+the `word', `symbol' and `sexp' things, respectively.")
+
+(defvar meow-symbol-thing 'symbol
+  "The \\='thing\\=' used for marking and movement by symbols.
+
+The values is a \\='thing\\=' as understood by `thingatpt' - a symbol that will
+be passed to `forward-thing' and `bounds-of-thing-at-point', which see.
+
+This means that they must, at minimum, have a function as the value of their
+`forward-op' symbol property (or the function should be defined as
+`forward-SYMBOLNAME'). This function should accept a single argument, a number
+N, and should move over the next N things, in either the forward or backward
+direction depending on the sign of N. Examples of such functions include
+`forward-word', `forward-symbol' and `forward-sexp', which `thingatpt' uses for
+the `word', `symbol' and `sexp' things, respectively.")
+
 (defcustom meow-display-thing-help t
   "Whether to display the help prompt for meow-inner/bounds/begin/end-of-thing."
   :group 'meow


### PR DESCRIPTION
Allows users to customize the behavior of the commands related to marking and moving by words and symbols.

Make all commands related to words and symbols rely on `forward-thing` and `bounds-of-thing-at-point`. Then, define the 'thing's that these functions are called on in `meow--word-thing` and `meow--symbol-thing`. Now the user can define their own things and make Meow use them by setting these variables.

Meow users may find Emacs' default notions of 'word' and 'symbol' to be unsatisfactory for modal editing. For example, word movements tend to skip over non-alphanumeric characters, meaning that `meow-next-word` and `meow-back-word` will skip them when not expanding a selection. This commit allows users to redefine these notions via `thingatpt`.

With this change, every Meow motion is now customizable. The only exception is `meow-line`; it should not be necessary to change its behavior since Meow already provides `meow-visual-line`.