### PR TITLE
Fixed freezing emacs when no input is provided to the meow-visit minibuffer

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -1406,14 +1406,12 @@ To search backward, use \\[negative-argument]."
                (end (if (> pos visit-point) (marker-position marker-beg) (marker-position marker-end))))
           (thread-first
             (meow--make-selection '(select . visit) beg end)
-	    (meow--select))
+            (meow--select))
           (meow--push-search text)
-	  (meow--ensure-visible)
-	  (meow--highlight-regexp-in-buffer text)
-	  (setq meow--dont-remove-overlay t))
-      (message "Visit: %s failed" (if (string-empty-p text)
-				      "<empty>"
-				      text)))))
+          (meow--ensure-visible)
+          (meow--highlight-regexp-in-buffer text)
+          (setq meow--dont-remove-overlay t))
+      (message "Visit: %s failed" (if (string-empty-p text) "<empty>" text)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; THING

--- a/meow-command.el
+++ b/meow-command.el
@@ -1376,7 +1376,6 @@ Argument REVERSE if selection is reversed."
     (save-mark-and-excursion
       (or (funcall func text nil t 1)
           (funcall func-2 text nil t 1)))))
-
 (defun meow-visit (arg)
   "Read a string from minibuffer, then find and select it.
 
@@ -1395,21 +1394,23 @@ To search backward, use \\[negative-argument]."
          (text (meow--prompt-symbol-and-words
                 (if arg "Visit backward: " "Visit: ")
                 (point-min) (point-max)))
-         (visit-point (meow--visit-point text reverse)))
-    (if visit-point
-        (let* ((m (match-data))
-               (marker-beg (car m))
-               (marker-end (cadr m))
-               (beg (if (> pos visit-point) (marker-position marker-end) (marker-position marker-beg)))
-               (end (if (> pos visit-point) (marker-position marker-beg) (marker-position marker-end))))
-          (thread-first
-            (meow--make-selection '(select . visit) beg end)
-            (meow--select))
-          (meow--push-search text)
-          (meow--ensure-visible)
-          (meow--highlight-regexp-in-buffer text)
-          (setq meow--dont-remove-overlay t))
-      (message "Visit: %s failed" text))))
+         (visit-point (if (string-empty-p text)
+                          nil
+                          (meow--visit-point text reverse))))
+        (if visit-point
+          (let* ((m (match-data))
+                 (marker-beg (car m))
+                 (marker-end (cadr m))
+                 (beg (if (> pos visit-point) (marker-position marker-end) (marker-position marker-beg)))
+                 (end (if (> pos visit-point) (marker-position marker-beg) (marker-position marker-end))))
+            (thread-first
+              (meow--make-selection '(select . visit) beg end)
+	      (meow--select))
+            (meow--push-search text)
+	    (meow--ensure-visible)
+	    (meow--highlight-regexp-in-buffer text)
+	    (setq meow--dont-remove-overlay t))
+	  (message "Visit: %s failed" text))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; THING

--- a/meow-command.el
+++ b/meow-command.el
@@ -1397,7 +1397,7 @@ To search backward, use \\[negative-argument]."
                 (point-min) (point-max)))
          (visit-point (if (string-empty-p text)
                           nil
-                         (meow--visit-point text reverse))))
+                          (meow--visit-point text reverse))))
     (if visit-point
         (let* ((m (match-data))
                (marker-beg (car m))

--- a/meow-command.el
+++ b/meow-command.el
@@ -1395,9 +1395,7 @@ To search backward, use \\[negative-argument]."
          (text (meow--prompt-symbol-and-words
                 (if arg "Visit backward: " "Visit: ")
                 (point-min) (point-max)))
-         (visit-point (if (string-empty-p text)
-                          nil
-                          (meow--visit-point text reverse))))
+         (visit-point (if (string-empty-p text) nil (meow--visit-point text reverse))))
     (if visit-point
         (let* ((m (match-data))
                (marker-beg (car m))

--- a/meow-command.el
+++ b/meow-command.el
@@ -1397,7 +1397,7 @@ To search backward, use \\[negative-argument]."
                 (point-min) (point-max)))
          (visit-point (if (string-empty-p text)
                           nil
-                        (meow--visit-point text reverse))))
+                         (meow--visit-point text reverse))))
     (if visit-point
         (let* ((m (match-data))
                (marker-beg (car m))

--- a/meow-command.el
+++ b/meow-command.el
@@ -1376,6 +1376,7 @@ Argument REVERSE if selection is reversed."
     (save-mark-and-excursion
       (or (funcall func text nil t 1)
           (funcall func-2 text nil t 1)))))
+
 (defun meow-visit (arg)
   "Read a string from minibuffer, then find and select it.
 
@@ -1396,21 +1397,23 @@ To search backward, use \\[negative-argument]."
                 (point-min) (point-max)))
          (visit-point (if (string-empty-p text)
                           nil
-                          (meow--visit-point text reverse))))
-        (if visit-point
-          (let* ((m (match-data))
-                 (marker-beg (car m))
-                 (marker-end (cadr m))
-                 (beg (if (> pos visit-point) (marker-position marker-end) (marker-position marker-beg)))
-                 (end (if (> pos visit-point) (marker-position marker-beg) (marker-position marker-end))))
-            (thread-first
-              (meow--make-selection '(select . visit) beg end)
-	      (meow--select))
-            (meow--push-search text)
-	    (meow--ensure-visible)
-	    (meow--highlight-regexp-in-buffer text)
-	    (setq meow--dont-remove-overlay t))
-	  (message "Visit: %s failed" text))))
+                        (meow--visit-point text reverse))))
+    (if visit-point
+        (let* ((m (match-data))
+               (marker-beg (car m))
+               (marker-end (cadr m))
+               (beg (if (> pos visit-point) (marker-position marker-end) (marker-position marker-beg)))
+               (end (if (> pos visit-point) (marker-position marker-beg) (marker-position marker-end))))
+          (thread-first
+            (meow--make-selection '(select . visit) beg end)
+	    (meow--select))
+          (meow--push-search text)
+	  (meow--ensure-visible)
+	  (meow--highlight-regexp-in-buffer text)
+	  (setq meow--dont-remove-overlay t))
+      (message "Visit: %s failed" (if (string-empty-p text)
+				      "<empty>"
+				      text)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; THING


### PR DESCRIPTION
When `(meow-visit)` is invoked and no input is provided in the minibuffer, Emacs freezes and hogs a CPU core.

this change adds a verification if `text` is empty, and if it is, `visit-point` is set to `nil`, triggering a `visit failed` message for the user.

It also adds a custom error message for this case, it being `Visit <empty> failed`.