### PR TITLE
Allow custom `delete-region`, `insert` functions

### DIFF
--- a/meow-beacon.el
+++ b/meow-beacon.el
@@ -504,7 +504,7 @@ The recorded kmacro will be applied to all cursors immediately."
                   (delete-overlay ov)))))))
 
 (defun meow--beacon-delete-region ()
-  (delete-region (region-beginning) (region-end)))
+  (meow--delete-region (region-beginning) (region-end)))
 
 (defun meow-beacon-kill-delete ()
   "Delete all selections.

--- a/meow-command.el
+++ b/meow-command.el
@@ -275,7 +275,7 @@ This command supports `meow-selection-command-fallback'."
         (t
          (meow--prepare-region-for-kill)
          (let ((s (buffer-substring-no-properties (region-beginning) (region-end))))
-           (delete-region (region-beginning) (region-end))
+           (meow--delete-region (region-beginning) (region-end))
            (kill-append (meow--prepare-string-for-kill-append s) nil))))))))
 
 (defun meow-C-k ()
@@ -465,7 +465,7 @@ This command supports `meow-selection-command-fallback'."
     (save-mark-and-excursion
       (newline))
     ;; (save-mark-and-excursion
-    ;;   (insert "\n"))
+    ;;   (meow--insert "\n"))
     (indent-according-to-mode)))
 
 (defun meow-open-above-visual ()
@@ -511,7 +511,7 @@ This command supports `meow-selection-command-fallback'."
   (when (meow--allow-modify-p)
     (setq this-command #'meow-change)
     (meow--with-selection-fallback
-     (delete-region (region-beginning) (region-end))
+     (meow--delete-region (region-beginning) (region-end))
      (meow--switch-state 'insert)
      (setq-local meow--insert-pos (point)))))
 
@@ -540,9 +540,9 @@ This command supports `meow-selection-command-fallback'."
    (let ((select-enable-clipboard meow-use-clipboard))
      (when (meow--allow-modify-p)
        (when-let ((s (string-trim-right (current-kill 0 t) "\n")))
-         (delete-region (region-beginning) (region-end))
+         (meow--delete-region (region-beginning) (region-end))
          (set-marker meow--replace-start-marker (point))
-         (insert s))))))
+         (meow--insert s))))))
 
 (defun meow-replace-char ()
   "Replace current char with selection."
@@ -550,9 +550,9 @@ This command supports `meow-selection-command-fallback'."
   (let ((select-enable-clipboard meow-use-clipboard))
     (when (< (point) (point-max))
       (when-let ((s (string-trim-right (current-kill 0 t) "\n")))
-        (delete-region (point) (1+ (point)))
+        (meow--delete-region (point) (1+ (point)))
         (set-marker meow--replace-start-marker (point))
-        (insert s)))))
+        (meow--insert s)))))
 
 (defun meow-replace-save ()
   (interactive)
@@ -566,12 +566,12 @@ This command supports `meow-selection-command-fallback'."
                            (meow--prepare-region-for-kill)
                            (buffer-substring-no-properties (region-beginning) (region-end)))))
                 (progn
-                  (delete-region (region-beginning) (region-end))
+                  (meow--delete-region (region-beginning) (region-end))
                   (set-marker meow--replace-start-marker (point))
-                  (insert s)
+                  (meow--insert s)
                   (kill-new old)))
             (set-marker meow--replace-start-marker (point))
-            (insert s)))))))
+            (meow--insert s)))))))
 
 (defun meow-replace-pop ()
   "Like `yank-pop', but for `meow-replace'.
@@ -599,9 +599,9 @@ For custom commands, see also the user option
         (message "`meow-replace-pop': Reached end of kill ring"))
       (let ((txt (string-trim-right (current-kill meow--replace-pop-index t)
                                     "\n")))
-        (delete-region meow--replace-start-marker (point))
+        (meow--delete-region meow--replace-start-marker (point))
         (set-marker meow--replace-start-marker (point))
-        (insert txt))))
+        (meow--insert txt))))
   (setq this-command 'meow-replace-pop))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1726,8 +1726,8 @@ This command is a replacement for built-in `kmacro-end-macro'."
          (region-str (when (region-active-p) (buffer-substring-no-properties rbeg rend)))
          (sel-str (meow--second-sel-get-string))
          (next-marker (make-marker)))
-    (when region-str (delete-region rbeg rend))
-    (when sel-str (insert sel-str))
+    (when region-str (meow--delete-region rbeg rend))
+    (when sel-str (meow--insert sel-str))
     (move-marker next-marker (point))
     (meow--second-sel-set-string (or region-str ""))
     (when (overlayp mouse-secondary-overlay)

--- a/meow-util.el
+++ b/meow-util.el
@@ -340,6 +340,14 @@ Looks up the state in meow-replace-state-name-list"
   (when-let ((bounds (bounds-of-thing-at-point thing)))
     (cons type bounds)))
 
+(defun meow--insert (&rest args)
+  "Use `meow--insert-function' to insert ARGS at point."
+  (apply meow--insert-function args))
+
+(defun meow--delete-region (start end)
+  "Use `meow--delete-region-function' to delete text between START and END."
+  (funcall meow--delete-region-function start end))
+
 (defun meow--push-search (search)
   (unless (string-equal search (car regexp-search-ring))
     (add-to-history 'regexp-search-ring search regexp-search-ring-max)))
@@ -419,7 +427,7 @@ Looks up the state in meow-replace-state-name-list"
   (when (or (member this-command meow-grab-fill-commands)
             (member meow--keypad-this-command meow-grab-fill-commands))
     (when-let ((s (meow--second-sel-get-string)))
-      (insert s))))
+      (meow--insert s))))
 
 (defun meow--parse-string-to-keypad-keys (str)
   (let ((strs (split-string str " ")))
@@ -536,12 +544,12 @@ that bound to DEF. Otherwise, return DEF."
    ((meow--second-sel-buffer)
     (with-current-buffer (overlay-buffer mouse-secondary-overlay)
       (goto-char (overlay-start mouse-secondary-overlay))
-      (delete-region (overlay-start mouse-secondary-overlay) (overlay-end mouse-secondary-overlay))
-      (insert string)))
+      (meow--delete-region (overlay-start mouse-secondary-overlay) (overlay-end mouse-secondary-overlay))
+      (meow--insert string)))
    ((markerp mouse-secondary-start)
     (with-current-buffer (marker-buffer mouse-secondary-start)
       (goto-char (marker-position mouse-secondary-start))
-      (insert string)))))
+      (meow--insert string)))))
 
 (defun meow--second-sel-get-string ()
   (when (meow--second-sel-buffer)

--- a/meow-var.el
+++ b/meow-var.el
@@ -508,6 +508,17 @@ Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 (defvar meow--kbd-goto-line "M-g g"
   "KBD macro for command `goto-line'.")
 
+(defvar meow--delete-region-function #'delete-region
+  "The function used to delete the selection.
+
+Allows support of modes that define their own equivalent of
+`delete-region'.")
+
+(defvar meow--insert-function #'insert
+  "The function used to insert text in Normal state.
+
+Allows support of modes that define their own equivalent of `insert'.")
+
 (defvar-local meow--indicator nil
   "Indicator for current buffer.")
 


### PR DESCRIPTION
Make it possible to specify which functions are used to delete the region and insert text.

This is needed to get Meow to work with modes like Vterm, that define their own `delete-region` and `insert` functions, without massive code duplication.

See [meow-vterm](https://github.com/45mg/meow-vterm) for an example of this - it requires this patch to work.