### PR TITLE
Fix behavior of meow-next-thing

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -807,8 +807,8 @@ This will shrink the word selection only contains
        (1- pos)))
     (let ((bounds (bounds-of-thing-at-point thing)))
       (if (> mark pos)
-          (cdr bounds)
-        (car bounds)))))
+          (min mark (cdr bounds))
+        (max mark (car bounds))))))
 
 (defun meow-next-thing (thing type n)
   "Create non-expandable selection of TYPE to the end of the next Nth THING.


### PR DESCRIPTION
# The Behaviour

`meow-next-word` like commands received a very odd behavior from #596. The behavior is as follows: [`|` is the cursor]

```
hello wo|rld

> run meow-next-word

hello world
      ^^^^^ gets selected
      
> whereas previously

hello world
        ^^^ would get selected
```

I understand this is done to prevent the following issue:

```
func|(arg)

> run meow-next-word before #596

func(arg)
    ^^^^ gets selected, which is annoying
    
> after #596

func(arg)
     ^^^ gets selected, like it should
```

# The Problem With That Behaviour

The new way of expanding all the way to `bounds-of-thing`, prevents vim motions like `dw` or `cw` to delete/change to the end of the word or symbol. Therefore, the following example is no longer possible after #596:

```
struct FooBaz|Bar

> run meow-next-word

struct FooBazBar
             ^^^ gets selected
             
> run meow-kill

struct FooBar
```

# The Solution

This PR makes it so that if `meow-next-thing` is called on `thing`, and the `mark` is already within the bounds of `thing`, then it no longer changes the `mark`.

This preserves the functionality of #596 without preventing motions that were previously possible.