### PR TITLE
Add options for selecting after `meow-insert` and `meow-append`.

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -436,7 +436,9 @@ This command supports `meow-selection-command-fallback'."
         (meow--switch-state 'motion))
     (meow--direction-backward)
     (meow--cancel-selection)
-    (meow--switch-state 'insert)))
+    (meow--switch-state 'insert)
+    (when meow-select-on-insert
+      (setq-local meow--insert-pos (point)))))
 
 (defun meow-append ()
   "Move to the end of selection, switch to INSERT state."
@@ -451,7 +453,9 @@ This command supports `meow-selection-command-fallback'."
           (forward-char 1))
       (meow--direction-forward)
       (meow--cancel-selection))
-    (meow--switch-state 'insert)))
+    (meow--switch-state 'insert)
+    (when meow-select-on-append
+      (setq-local meow--insert-pos (point)))))
 
 (defun meow-open-above ()
   "Open a newline above and switch to INSERT state."
@@ -513,7 +517,8 @@ This command supports `meow-selection-command-fallback'."
     (meow--with-selection-fallback
      (delete-region (region-beginning) (region-end))
      (meow--switch-state 'insert)
-     (setq-local meow--insert-pos (point)))))
+     (when meow-select-on-change
+       (setq-local meow--insert-pos (point))))))
 
 (defun meow-change-char ()
   "Delete current char and switch to INSERT state."
@@ -521,7 +526,8 @@ This command supports `meow-selection-command-fallback'."
   (when (< (point) (point-max))
     (meow--execute-kbd-macro meow--kbd-delete-char)
     (meow--switch-state 'insert)
-    (setq-local meow--insert-pos (point))))
+    (when meow-select-on-change
+      (setq-local meow--insert-pos (point)))))
 
 (defun meow-change-save ()
   (interactive)
@@ -529,7 +535,8 @@ This command supports `meow-selection-command-fallback'."
     (when (and (meow--allow-modify-p) (region-active-p))
       (kill-region (region-beginning) (region-end))
       (meow--switch-state 'insert)
-      (setq-local meow--insert-pos (point)))))
+      (when meow-select-on-change
+        (setq-local meow--insert-pos (point))))))
 
 (defun meow-replace ()
   "Replace current selection with yank.

--- a/meow-core.el
+++ b/meow-core.el
@@ -43,7 +43,9 @@
   (if meow-insert-mode
       (run-hooks 'meow-insert-enter-hook)
     (when (and meow--insert-pos
-               meow-select-on-change
+               (or meow-select-on-change
+                   meow-select-on-append
+                   meow-select-on-insert)
                (not (= (point) meow--insert-pos)))
       (thread-first
         (meow--make-selection '(select . transient) meow--insert-pos (point))

--- a/meow-var.el
+++ b/meow-var.el
@@ -82,6 +82,16 @@ This will affect how selection is displayed."
   :group 'meow
   :type 'boolean)
 
+(defcustom meow-select-on-append nil
+  "Whether to activate region when exiting INSERT mode after `meow-append'."
+  :group 'meow
+  :type 'boolean)
+
+(defcustom meow-select-on-insert nil
+  "Whether to activate region when exiting INSERT mode after `meow-insert'."
+  :group 'meow
+  :type 'boolean)
+
 (defcustom meow-expand-hint-remove-delay 1.0
   "The delay before the position hint disappears."
   :group 'meow


### PR DESCRIPTION
- Add `meow-select-on-append`, defaulting to `nil` to maintain previous behavior.  Make `meow-append` set `meow--insert-pos` when non-nil.

- Add `meow-select-on-insert`, defaulting to `nil` to maintain previous behavior. Make `meow-insert` set `meow--insert-pos` when non-nil.

- Modify `meow-change`, `meow-change-char`, and `meow-change-save` to set `meow--insert-pos` when `meow-select-on-change` is non-nil, instead of always setting it.

- Modify Insert state to also consider the new variables.


I find the behavior of selecting after `meow-change` very useful, but I don't always remember that it is limited to the `change` commands. Having that behavior available for `meow-insert` and `meow-append` means one less thing to remember when editing in the flow.