### PR TITLE
Fix byte-compilation warnings

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -1293,9 +1293,10 @@ with UNIVERSAL ARGUMENT, search both side."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun meow-search (arg)
-  " Search and select with the car of current `regexp-search-ring'.
+  "Search and select with the car of current `regexp-search-ring'.
 
-If the contents of selection doesn't match the regexp, will push it to `regexp-search-ring' before searching.
+If the contents of selection doesn't match the regexp, will push
+it to `regexp-search-ring' before searching.
 
 To search backward, use \\[negative-argument]."
   (interactive "P")
@@ -1359,11 +1360,13 @@ Argument REVERSE if selection is reversed."
   "Read a string from minibuffer, then find and select it.
 
 The input will be pushed into `regexp-search-ring'.  So
-\\[meow-search] can be used for further searching with the same condition.
+\\[meow-search] can be used for further searching with the same
+condition.
 
-A list of words and symbols in the current buffer will be provided for completion.
-To search for regexp instead, set `meow-visit-sanitize-completion' to nil.
-In that case, completions will be provided in regexp form, but also covering
+A list of words and symbols in the current buffer will be
+provided for completion.  To search for regexp instead, set
+`meow-visit-sanitize-completion' to nil.  In that case,
+completions will be provided in regexp form, but also covering
 the words and symbols in the current buffer.
 
 To search backward, use \\[negative-argument]."
@@ -1750,17 +1753,17 @@ This command is a replacement for built-in `kmacro-end-macro'."
      (setq mouse-secondary-start next-marker)
      (meow--cancel-selection))))
 
-(defun meow-describe-key (key-list &optional buffer up-event)
+(defun meow-describe-key (key-list &optional buffer)
   (interactive (list (help--read-key-sequence)))
   (if (= 1 (length key-list))
       (let* ((key (format-kbd-macro (cdar key-list)))
              (cmd (key-binding key)))
         (if-let ((dispatch (and (commandp cmd)
                                 (get cmd 'meow-dispatch))))
-            (describe-key (kbd dispatch) buffer up-event)
-          (describe-key key-list buffer up-event)))
+            (describe-key (kbd dispatch) buffer)
+          (describe-key key-list buffer)))
     ;; for mouse events
-    (describe-key key-list buffer up-event)))
+    (describe-key key-list buffer)))
 
 ;; aliases
 (defalias 'meow-backward-delete 'meow-backspace)

--- a/meow-esc.el
+++ b/meow-esc.el
@@ -30,6 +30,7 @@
   "Mode that ensures ESC works in the terminal"
   :init-value nil
   :global t
+  :group 'meow
   :keymap nil
   (if meow-esc-mode
       (progn

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -46,19 +46,19 @@ string SUFFIX. Then, convert this string into a symbol."
 Example usage:
   (meow-define-keys
     ;; state
-    'normal
+    \\='normal
 
     ;; bind to a command
-    '(\"a\" . meow-append)
+    \\='(\"a\" . meow-append)
 
     ;; bind to a keymap
     (cons \"x\" ctl-x-map)
 
     ;; bind to a keybinding which holds a keymap
-    '(\"c\" . \"C-c\")
+    \\='(\"c\" . \"C-c\")
 
     ;; bind to a keybinding which holds a command
-    '(\"q\" . \"C-x C-q\"))"
+    \\='(\"q\" . \"C-x C-q\"))"
   (declare (indent 1))
   (let ((map (alist-get state meow-keymap-alist)))
     (pcase-dolist (`(,key . ,def) keybinds)
@@ -70,16 +70,16 @@ Example usage:
 Example usage:
   (meow-normal-define-key
     ;; bind to a command
-    '(\"a\" . meow-append)
+    \\='(\"a\" . meow-append)
 
     ;; bind to a keymap
     (cons \"x\" ctl-x-map)
 
     ;; bind to a keybinding which holds a keymap
-    '(\"c\" . \"C-c\")
+    \\='(\"c\" . \"C-c\")
 
     ;; bind to a keybinding which holds a command
-    '(\"q\" . \"C-x C-q\"))"
+    \\='(\"q\" . \"C-x C-q\"))"
   (apply #'meow-define-keys 'normal keybinds))
 
 (defun meow-leader-define-key (&rest keybinds)
@@ -196,7 +196,7 @@ Example usage:
 (meow-define-state mystate
   \"My meow state\"
   :lighter \" [M]\"
-  :keymap 'my-keymap
+  :keymap \\='my-keymap
   (message \"toggled state\"))
 
 Also see meow-register-state, which is used internally by this
@@ -209,7 +209,7 @@ This function produces several items:
 2. meow-NAME-mode-p: a predicate for whether the state is active.
 3. meow-cursor-type-NAME: a variable for the cursor type for the state.
 4. meow--update-cursor-NAME: a function that sets the cursor type to 3.
- and face FACE or 'meow-unknown cursor if FACE is nil."
+ and face FACE or \\='meow-unknown cursor if FACE is nil."
   (declare (indent 1))
   (let ((name       (symbol-name name-sym))
         (init-value (plist-get body :init-value))

--- a/meow-shims.el
+++ b/meow-shims.el
@@ -118,9 +118,9 @@ Argument ENABLE non-nil means turn on."
         (advice-add 'diff-hl-show-hunk-inline-popup :before 'meow--switch-to-motion)
         (advice-add 'diff-hl-show-hunk-posframe :before 'meow--switch-to-motion)
         (advice-add 'diff-hl-show-hunk-hide :after 'meow--switch-to-normal))
-    (advice-remove diff-hl-show-hunk-inline-popup 'meow--switch-to-motion)
-    (advice-remove diff-hl-show-hunk-posframe 'meow--switch-to-motion)
-    (advice-remove diff-hl-show-hunk-hide 'meow--switch-to-normal)))
+    (advice-remove 'diff-hl-show-hunk-inline-popup 'meow--switch-to-motion)
+    (advice-remove 'diff-hl-show-hunk-posframe 'meow--switch-to-motion)
+    (advice-remove 'diff-hl-show-hunk-hide 'meow--switch-to-normal)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; wgrep
@@ -272,6 +272,10 @@ Argument ENABLE non-nil means turn on."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; which-key
 
+(defvar which-key-mode)
+(declare-function which-key--create-buffer-and-show "which-key"
+                  (&optional prefix-keys from-keymap filter prefix-title))
+
 (defvar meow--which-key-setup nil)
 
 (defun meow--which-key-describe-keymap ()
@@ -293,7 +297,9 @@ Argument ENABLE non-nil means turn on."
 (defvar meow--input-method-setup nil)
 
 (defun meow--input-method-advice (fnc key)
-  "Intended to be advice for quail-input-method. Only use the input method in insert mode."
+  "Advice for `quail-input-method'.
+
+Only use the input method in insert mode."
   (funcall (if (and (boundp 'meow-mode) meow-mode (not (meow-insert-mode-p))) #'list fnc) key))
 
 (defun meow--setup-input-method (enable)
@@ -305,6 +311,8 @@ Argument ENABLE non-nil means turn on."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ddskk
 
+(defvar skk-henkan-mode)
+
 (defvar meow--ddskk-setup nil)
 (defun meow--ddskk-skk-previous-candidate-advice (fnc &optional arg)
   (if (and (not (eq skk-henkan-mode 'active))
@@ -314,7 +322,7 @@ Argument ENABLE non-nil means turn on."
                (seq-first (car (where-is-internal
                                 'meow-prev
                                 meow-normal-state-keymap)))))
-      (previous-line)
+      (forward-line -1)
     (funcall fnc arg)))
 
 (defun meow--setup-ddskk (enable)

--- a/meow-thing.el
+++ b/meow-thing.el
@@ -252,15 +252,15 @@ SYMBOL is a symbol represent a builtin thing.
 
   Example: url
 
-    (meow-thing-register 'url 'url 'url)
+    (meow-thing-register \\='url \\='url \\='url)
 
 SYNTAX-EXPR contains a syntax description used by `skip-syntax-forward'
 
   Example: non-whitespaces
 
-    (meow-thing-register 'non-whitespace
-                         '(syntax . \"^-\")
-                         '(syntax . \"^-\"))
+    (meow-thing-register \\='non-whitespace
+                         \\='(syntax . \"^-\")
+                         \\='(syntax . \"^-\"))
 
   You can find the description for syntax in current buffer with
   \\[describe-syntax].
@@ -272,9 +272,9 @@ REGEXP-EXPR contains two regexps, the first is used for
 
   Example: quoted
 
-    (meow-thing-register 'quoted
-                         '(regexp \"`\" \"`\\\\|'\")
-                         '(regexp \"`\" \"`\\\\|'\"))
+    (meow-thing-register \\='quoted
+                         \\='(regexp \"\\=`\" \"\\=`\\\\|\\='\")
+                         \\='(regexp \"\\=`\" \"\\=`\\\\|\\='\"))
 
 PAIR-EXPR contains two string token lists. The tokens in first
   list are used for finding beginning, the tokens in second list
@@ -283,9 +283,9 @@ PAIR-EXPR contains two string token lists. The tokens in first
 
   Example: do/end block
 
-    (meow-thing-register 'do/end
-                         '(pair (\"do\") (\"end\"))
-                         '(pair (\"do\") (\"end\")))"
+    (meow-thing-register \\='do/end
+                         \\='(pair (\"do\") (\"end\"))
+                         \\='(pair (\"do\") (\"end\")))"
     (let ((inner-fn (meow--thing-parse inner t))
           (bounds-fn (meow--thing-parse bounds nil)))
       (meow--thing-register thing inner-fn bounds-fn)))

--- a/meow-util.el
+++ b/meow-util.el
@@ -198,12 +198,14 @@ Looks up the state in meow-replace-state-name-list"
     (meow--update-cursor)))
 
 (defun meow--switch-state (state &optional no-hook)
-  "Switch to STATE execute 'meow-switch-state-hook unless NO-HOOK is non-nil."
+  "Switch to STATE execute `meow-switch-state-hook' unless NO-HOOK is non-nil."
   (unless (eq state (meow--current-state))
     (let ((mode (alist-get state meow-state-mode-alist)))
       (funcall mode 1))
     (unless (bound-and-true-p no-hook)
       (run-hook-with-args 'meow-switch-state-hook state))))
+
+(defvar meow--beacon-apply-command "meow-beacon")
 
 (defun meow--exit-keypad-state ()
   "Exit keypad state."

--- a/meow-var.el
+++ b/meow-var.el
@@ -345,7 +345,7 @@ Nil means find the command by key binding."
 To integrate WhichKey-like features with keypad.
 Currently, keypad is not working well with which-key,
 so Meow ships a default `meow-describe-keymap'.
-Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
+Use (setq meow-keypad-describe-keymap-function \\='nil) to disable popup.")
 
 (defvar meow-keypad-get-title-function 'meow-keypad-get-title
   "The function used to get the title of a keymap or command.")


### PR DESCRIPTION
This PR fixes various compilation warnings.

Note: this PR also changes the calling convention for `meow-describe-key`, you may want to handle that in a different way.