### PR TITLE
colemak: delete duplicate meow-delete binding

### DIFF
--- a/KEYBINDING_COLEMAK.org
+++ b/KEYBINDING_COLEMAK.org
@@ -55,7 +55,6 @@ Add it to your configuration and call it before ~(meow-global-mode 1)~.
      '("b" . meow-back-word)
      '("B" . meow-back-symbol)
      '("c" . meow-change)
-     '("d" . meow-delete)
      '("e" . meow-prev)
      '("E" . meow-prev-expand)
      '("f" . meow-find)


### PR DESCRIPTION
`meow-delete` is bound to `x`. I think this was left over from previous keybindings.

Also, note `meow-swap-grab` and `meow-sync-grab` are not bound. Not sure where to put them yet.
