### PR TITLE
Add `meow(-backward)-kill-{word,symbol}`

### DIFF
--- a/COMMANDS.org
+++ b/COMMANDS.org
@@ -195,10 +195,11 @@ Call the command on ~C-k~.
 
 Call the command on ~C-d~.
 
-*** meow-kill-word, meow-backward-kill-word
+*** meow-kill-word, meow-backward-kill-word, meow-kill-symbol, meow-backward-kill-symbol
 
- Versions of ~kill-word~ and ~backward-kill-word~ that respect
-~meow-word-thing~.
+Versions of ~kill-word~ and ~backward-kill-word~ that respect ~meow-word-thing~
+and ~meow-symbol-thing~. May be bound to M-d and M-DEL in place of ~kill-word~
+and ~backward-kill-word~.
 
 *** meow-save
 

--- a/COMMANDS.org
+++ b/COMMANDS.org
@@ -195,6 +195,11 @@ Call the command on ~C-k~.
 
 Call the command on ~C-d~.
 
+*** meow-kill-word, meow-backward-kill-word
+
+ Versions of ~kill-word~ and ~backward-kill-word~ that respect
+~meow-word-thing~.
+
 *** meow-save
 
 Copy.

--- a/CUSTOMIZATIONS.org
+++ b/CUSTOMIZATIONS.org
@@ -183,6 +183,7 @@ Default: ='((?c . ?c) (?h . ?h) (?x . ?x))=
 Alist of keys to begin keypad translation. For instance, given the default
 value, pressing "c" in keypad mode will look up it's value in the alist, and
 add "C-c" to the keypad.
+
 ** meow-keypad-self-insert-undefined
 
 Default: =t=
@@ -225,6 +226,7 @@ Default:
 #+end_src
 
 A association list of state symbols to strings describing the state.
+
 ** meow-indicator-face-alist
 Default:
 
@@ -410,3 +412,6 @@ to Vim's -
 
 (setq meow-word-thing 'vimlike-word)
 #+end_src
+
+Meow also provides ~meow-kill-word~ and ~meow-backward-kill-word~, versions of
+~kill-word~ and ~backward-kill-word~ that respect ~meow-word-thing~.

--- a/meow-command.el
+++ b/meow-command.el
@@ -306,11 +306,29 @@ With argument ARG, do this that many times."
   (meow-kill-word (- arg)))
 
 (defun meow-kill-word (arg)
-  "Kill characters forward until the beginning of a `meow-word-thing'.
+  "Kill characters forward until the end of a `meow-word-thing'.
 With argument ARG, do this that many times."
   (interactive "p")
+  (meow-kill-thing meow-word-thing arg))
+
+(defun meow-backward-kill-symbol (arg)
+  "Kill characters backward until the beginning of a `meow-symbol-thing'.
+With argument ARG, do this that many times."
+  (interactive "p")
+  (meow-kill-symbol (- arg)))
+
+(defun meow-kill-symbol (arg)
+  "Kill characters forward until the end of a `meow-symbol-thing'.
+With argument ARG, do this that many times."
+  (interactive "p")
+  (meow-kill-thing meow-symbol-thing arg))
+
+
+(defun meow-kill-thing (thing arg)
+  "Kill characters forward until the end of a THING.
+With argument ARG, do this that many times."
   (let ((start (point))
-        (end (progn (forward-thing meow-word-thing arg) (point))))
+        (end (progn (forward-thing thing arg) (point))))
     (condition-case _
         (kill-region start end)
       ((text-read-only buffer-read-only)

--- a/meow-command.el
+++ b/meow-command.el
@@ -299,6 +299,25 @@ This command supports `meow-selection-command-fallback'."
   (interactive)
   (meow--execute-kbd-macro meow--kbd-delete-char))
 
+(defun meow-backward-kill-word (arg)
+  "Kill characters backward until the beginning of a `meow-word-thing'.
+With argument ARG, do this that many times."
+  (interactive "p")
+  (meow-kill-word (- arg)))
+
+(defun meow-kill-word (arg)
+  "Kill characters forward until the beginning of a `meow-word-thing'.
+With argument ARG, do this that many times."
+  (interactive "p")
+  (let ((start (point))
+        (end (progn (forward-thing meow-word-thing arg) (point))))
+    (condition-case _
+        (kill-region start end)
+      ((text-read-only buffer-read-only)
+       (condition-case err
+           (meow--delete-region start end)
+         (t (signal (car err) (cdr err))))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; PAGE UP&DOWN
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Versions of `kill-word` and `backward-kill-word` that respect `meow-word-thing`
and `meow-symbol-thing`. May be bound to M-d and M-DEL in place of `kill-word`
and `backward-kill-word`.
