### PR TITLE
Add a shim for grep-edit

### DIFF
--- a/meow-shims.el
+++ b/meow-shims.el
@@ -148,6 +148,28 @@ Argument ENABLE non-nil means turn on."
     (advice-remove 'wgrep-save-all-buffers #'meow--switch-to-motion)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; grep-edit
+
+
+(defvar meow--grep-edit-setup nil
+  "Wheter already setup grep-edit.")
+
+(defvar grep-edit-mode-hook)
+
+(declare-function grep-edit-save-changes "grep")
+
+(defun meow--setup-grep-edit (enable)
+  "Setup grep-edit.
+
+Argument ENABLE non-nil means turn on."
+  (if enable
+      (progn
+        (add-hook 'grep-edit-mode-hook #'meow--switch-to-normal)
+        (advice-add #'grep-edit-save-changes :after #'meow--switch-to-motion))
+    (remove-hook 'grep-edit-mode-hook #'meow--switch-to-normal)
+    (advice-remove 'grep-edit-save-changes #'meow--switch-to-motion)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; wdired
 
 (defvar meow--wdired-setup nil
@@ -465,6 +487,7 @@ Argument ENABLE non-nil means turn on."
   (eval-after-load "edebug" (lambda () (meow--setup-edebug t)))
   (eval-after-load "magit" (lambda () (meow--setup-magit t)))
   (eval-after-load "wgrep" (lambda () (meow--setup-wgrep t)))
+  (eval-after-load "grep" (lambda () (meow--setup-grep-edit t)))
   (eval-after-load "company" (lambda () (meow--setup-company t)))
   (eval-after-load "polymode" (lambda () (meow--setup-polymode t)))
   (eval-after-load "cider" (lambda () (meow--setup-cider t)))
@@ -487,6 +510,7 @@ Argument ENABLE non-nil means turn on."
   (when meow--magit-setup (meow--setup-magit nil))
   (when meow--company-setup (meow--setup-company nil))
   (when meow--wgrep-setup (meow--setup-wgrep nil))
+  (when meow--grep-edit-setup (meow--setup-grep-edit nil))
   (when meow--polymode-setup (meow--setup-polymode nil))
   (when meow--cider-setup (meow--setup-cider nil))
   (when meow--which-key-setup (meow--setup-which-key nil))


### PR DESCRIPTION
`grep-edit` is a major mode introduced in Emacs 31 (introduced in commit [db1eb8a2](https://git.savannah.gnu.org/cgit/emacs.git/commit/etc/NEWS?id=db1eb8a282c1832fd34be049e80dcb1a3b59ade2)) which enables the editing of Grep results, by typing 'e' in '*grep*' buffers. 'C-c C-c' exits this mode and saves changes. It can be used as a built-in replacement of [wgrep](https://github.com/mhayashi1120/Emacs-wgrep).

I can hold this PR back if it causes any issues in earlier versions.