### PR TITLE
Add eat-eshell shim

### DIFF
--- a/meow-shims.el
+++ b/meow-shims.el
@@ -469,6 +469,35 @@ Argument ENABLE non-nil means turn on."
       ;; These vars allow us the select through the polymode chunk
       (add-to-list 'polymode-move-these-vars-from-old-buffer v))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; eat-eshell
+
+(defvar meow--eat-eshell-setup nil)
+(defvar meow--eat-eshell-entered-emacs-mode nil)
+
+(declare-function eat-eshell-emacs-mode "eat")
+(declare-function eat-eshell-semi-char-mode "eat")
+
+(defun meow--eat-eshell-maybe-enter-emacs-mode ()
+  (when (bound-and-true-p eat--eshell-semi-char-mode)
+    (setq meow--eat-eshell-entered-emacs-mode t)
+    (eat-eshell-emacs-mode)))
+
+(defun meow--eat-eshell-maybe-enter-semi-char-mode ()
+  (when meow--eat-eshell-entered-emacs-mode
+    (setq meow--eat-eshell-entered-emacs-mode nil)
+    (eat-eshell-semi-char-mode)))
+
+(defun meow--setup-eat-eshell (enable)
+  (setq meow--eat-eshell-setup enable)
+  (if enable
+      (progn (add-hook 'eat-eshell-exit-hook #'meow--update-cursor)
+             (add-hook 'meow-insert-mode-hook #'meow--eat-eshell-maybe-enter-semi-char-mode)
+             (add-hook 'meow-normal-mode-hook #'meow--eat-eshell-maybe-enter-emacs-mode))
+    (remove-hook 'eat-eshell-exit-hook #'meow--update-cursor)
+    (remove-hook 'meow-insert-mode-hook #'meow--eat-eshell-maybe-enter-semi-char-mode)
+    (remove-hook 'meow-normal-mode-hook #'meow--eat-eshell-maybe-enter-emacs-mode)))
+
 ;; Enable / Disable shims
 
 (defun meow--enable-shims ()
@@ -495,7 +524,8 @@ Argument ENABLE non-nil means turn on."
   (eval-after-load "undo-tree" (lambda () (meow--setup-undo-tree t)))
   (eval-after-load "diff-hl" (lambda () (meow--setup-diff-hl t)))
   (eval-after-load "quail" (lambda () (meow--setup-input-method t)))
-  (eval-after-load "skk" (lambda () (meow--setup-ddskk t))))
+  (eval-after-load "skk" (lambda () (meow--setup-ddskk t)))
+  (eval-after-load "eat" (lambda () (meow--setup-eat-eshell t))))
 
 (defun meow--disable-shims ()
   "Remove shim setups."
@@ -514,7 +544,8 @@ Argument ENABLE non-nil means turn on."
   (when meow--which-key-setup (meow--setup-which-key nil))
   (when meow--diff-hl-setup (meow--setup-diff-hl nil))
   (when meow--input-method-setup (meow--setup-input-method nil))
-  (when meow--ddskk-setup (meow--setup-ddskk nil)))
+  (when meow--ddskk-setup (meow--setup-ddskk nil))
+  (when meow--eat-eshell-setup (meow--setup-eat-eshell nil)))
 
 ;;; meow-shims.el ends here
 (provide 'meow-shims)


### PR DESCRIPTION
eat-eshell is a mode for eat integration for eshell. This lets you run visual commands directly in eshell instead of having it open it in a separate term buffer.

After a visual command has completed and it returns to eshell it doesn't update the cursor so we should do that on the exit-hook.

As it goes from eshell which is effectively running in line-mode, to eat in semi-char-mode, the experience can be a bit jarring. In semi-char-mode you can't really move around. Moving up and down would instead cycle through the command history. By toggling emacs-mode on entering normal mode makes this experience nicer, though as the some work would be needed to make pasting from normal mode working.

I'm not thrilled about relying on `eat--eshell-semi-char-mode`, maybe this is fragile? This was the only way I could come up with to track which mode we are in.

The rest of eat could probably use a similar shim, but I don't really use the rest so it might be better for someone who do to implement it.