### PR TITLE
Make the placing of marks consistant for INSERT state.

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -492,8 +492,9 @@ With argument ARG, do this that many times."
     (meow--direction-backward)
     (meow--cancel-selection)
     (meow--switch-state 'insert)
+    (setq-local meow--insert-pos (point))
     (when meow-select-on-insert
-      (setq-local meow--insert-pos (point)))))
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-append ()
   "Move to the end of selection, switch to INSERT state."
@@ -509,8 +510,9 @@ With argument ARG, do this that many times."
       (meow--direction-forward)
       (meow--cancel-selection))
     (meow--switch-state 'insert)
+    (setq-local meow--insert-pos (point))
     (when meow-select-on-append
-      (setq-local meow--insert-pos (point)))))
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-open-above ()
   "Open a newline above and switch to INSERT state."
@@ -525,7 +527,10 @@ With argument ARG, do this that many times."
       (newline))
     ;; (save-mark-and-excursion
     ;;   (meow--insert "\n"))
-    (indent-according-to-mode)))
+    (indent-according-to-mode)
+    (setq-local meow--insert-pos (point))
+    (when meow-select-on-open
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-open-above-visual ()
   "Open a newline above and switch to INSERT state."
@@ -538,7 +543,10 @@ With argument ARG, do this that many times."
     (goto-char (meow--visual-line-beginning-position))
     (save-mark-and-excursion
       (newline))
-    (indent-according-to-mode)))
+    (indent-according-to-mode)
+    (setq-local meow--insert-pos (point))
+    (when meow-select-on-open
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-open-below ()
   "Open a newline below and switch to INSERT state."
@@ -549,7 +557,10 @@ With argument ARG, do this that many times."
         (meow--switch-state 'motion))
     (meow--switch-state 'insert)
     (goto-char (line-end-position))
-    (meow--execute-kbd-macro "RET")))
+    (meow--execute-kbd-macro "RET")
+    (setq-local meow--insert-pos (point))
+    (when meow-select-on-open
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-open-below-visual ()
   "Open a newline below and switch to INSERT state."
@@ -560,7 +571,10 @@ With argument ARG, do this that many times."
         (meow--switch-state 'motion))
     (meow--switch-state 'insert)
     (goto-char (meow--visual-line-end-position))
-    (meow--execute-kbd-macro "RET")))
+    (meow--execute-kbd-macro "RET")
+    (setq-local meow--insert-pos (point))
+    (when meow-select-on-open
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-change ()
   "Kill current selection and switch to INSERT state.
@@ -572,8 +586,9 @@ This command supports `meow-selection-command-fallback'."
     (meow--with-selection-fallback
      (meow--delete-region (region-beginning) (region-end))
      (meow--switch-state 'insert)
+     (setq-local meow--insert-pos (point))
      (when meow-select-on-change
-       (setq-local meow--insert-pos (point))))))
+       (setq-local meow--insert-activate-mark t)))))
 
 (defun meow-change-char ()
   "Delete current char and switch to INSERT state."
@@ -581,8 +596,9 @@ This command supports `meow-selection-command-fallback'."
   (when (< (point) (point-max))
     (meow--execute-kbd-macro meow--kbd-delete-char)
     (meow--switch-state 'insert)
+    (setq-local meow--insert-pos (point))
     (when meow-select-on-change
-      (setq-local meow--insert-pos (point)))))
+      (setq-local meow--insert-activate-mark t))))
 
 (defun meow-change-save ()
   (interactive)
@@ -590,8 +606,9 @@ This command supports `meow-selection-command-fallback'."
     (when (and (meow--allow-modify-p) (region-active-p))
       (kill-region (region-beginning) (region-end))
       (meow--switch-state 'insert)
+      (setq-local meow--insert-pos (point))
       (when meow-select-on-change
-        (setq-local meow--insert-pos (point))))))
+        (setq-local meow--insert-activate-mark t)))))
 
 (defun meow-replace ()
   "Replace current selection with yank.

--- a/meow-core.el
+++ b/meow-core.el
@@ -43,15 +43,15 @@
   (if meow-insert-mode
       (run-hooks 'meow-insert-enter-hook)
     (when (and meow--insert-pos
-               (or meow-select-on-change
-                   meow-select-on-append
-                   meow-select-on-insert)
                (not (= (point) meow--insert-pos)))
       (thread-first
         (meow--make-selection '(select . transient) meow--insert-pos (point))
-        (meow--select)))
+        (meow--select))
+      (when (not meow--insert-activate-mark)
+        (deactivate-mark)))
     (run-hooks 'meow-insert-exit-hook)
-    (setq-local meow--insert-pos nil)))
+    (setq-local meow--insert-pos nil
+                meow--insert-activate-mark nil)))
 
 (meow-define-state normal
   "Meow NORMAL state minor mode."

--- a/meow-var.el
+++ b/meow-var.el
@@ -101,6 +101,13 @@ This doesn't affect how keypad works on recording or executing a kmacro."
   :group 'meow
   :type 'boolean)
 
+(defcustom meow-select-on-open nil
+  "Whether to activate region when exiting INSERT mode after
+`meow-open-above', `meow-open-below', `meow-open-above-visual'
+and `meow-open-below-visual'."
+  :group 'meow
+  :type 'boolean)
+
 (defcustom meow-expand-hint-remove-delay 1.0
   "The delay before the position hint disappears."
   :group 'meow
@@ -598,6 +605,9 @@ The value can be nil, quick or record.")
 
 (defvar-local meow--insert-pos nil
   "The position where we enter INSERT state.")
+
+(defvar-local meow--insert-activate-mark nil
+  "Whether the mark should be activated when we exit INSERT state.")
 
 (defvar meow-full-width-number-position-chars
   '((0 . "０")


### PR DESCRIPTION
Update so that entering and exiting INSERT state will place marks the same way whether 'meow-select-on-*' variable is set or not. This includes adding configuration options for 'meow-open-*' functions.

The variables now only affect if the resulting mark should be active or not when exiting INSERT state.

This is to address #651