### PR TITLE
Add `meow-pop-to-global-mark`

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -1564,6 +1564,16 @@ Before jump, a mark of current location will be created."
     (setq mark-ring (append mark-ring (list (point-marker)))))
   (pop-to-mark-command))
 
+(defun meow-pop-to-global-mark ()
+  "Alternative command to `pop-global-mark'.
+
+Before jump, a mark of current location will be created."
+  (interactive)
+  (meow--cancel-selection)
+  (unless (member last-command '(meow-pop-to-global-mark meow-pop-to-mark meow-unpop-to-mark))
+    (setq global-mark-ring (append global-mark-ring (list (point-marker)))))
+  (meow--execute-kbd-macro meow--kbd-pop-global-mark))
+
 (defun meow-back-to-indentation ()
   "Back to indentation."
   (interactive)

--- a/meow-var.el
+++ b/meow-var.el
@@ -533,6 +533,9 @@ Allows support of modes that define their own equivalent of `insert'.")
 
 Has a structure of (sel-type point mark).")
 
+(defvar meow--kbd-pop-global-mark "C-x C-@"
+  "KBD macro for command `pop-global-mark'.")
+
 ;;; Hooks
 
 (defvar meow-switch-state-hook nil


### PR DESCRIPTION
I think the only issue with this is if this key bind (C-x C-@) isn't available in ealier versions.

Let me know if you have it, my version is:

`GNU Emacs 31.0.50 (build 1, x86_64-redhat-linux-gnu, GTK+ Version 3.24.43, cairo version 1.18.0) of 2024-11-22`