### PR TITLE
Fix documentation string in meow--parse-def

### DIFF
--- a/meow-util.el
+++ b/meow-util.el
@@ -537,7 +537,7 @@ that bound to DEF. Otherwise, return DEF."
         (defalias cmd-name
           (lambda ()
             (:documentation
-             (format "Execute the command which is bound to %s." def))
+             (format "Execute the command which is bound to %s." (buttonize def 'describe-key (kbd def))))
             (interactive)
             (meow--execute-kbd-macro def)))
         (put cmd-name 'meow-dispatch def)


### PR DESCRIPTION
Updated the documentation string in the `meow--parse-def` function to use `buttonize` for better context. This change improves the clarity of the message displayed when executing commands bound to a key, ensuring it correctly reflects the keybinding being used.

this close #677 