### PR TITLE
meow--execute-kbd-macro: set the executed command as this-command

### DIFF
--- a/meow-util.el
+++ b/meow-util.el
@@ -56,6 +56,7 @@
   (when-let* ((ret (key-binding (read-kbd-macro kbd-macro))))
     (cond
      ((commandp ret)
+      (setq this-command ret)
       (call-interactively ret))
 
      ((and (not meow-use-keypad-when-execute-kbd) (keymapp ret))


### PR DESCRIPTION
meow-selection-command-fallback would benefit when the keybinding is a macro like
  (meow-normal-define-key
   '("z" . "C-c z"))

  (global-set-key (kbd C-c z) 'meow-pop-selection)