### PR TITLE
Fix meow--keypad-try-execute

### DIFF
--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -416,6 +416,10 @@ try replacing the last modifier and try again."
     (let* ((key-str (meow--keypad-format-keys nil))
            (cmd (meow--keypad-lookup-key (kbd key-str))))
       (cond
+       ((keymapp cmd)
+        (when meow-keypad-message (meow--keypad-show-message))
+        (meow--keypad-display-message)
+        nil)
        ((commandp cmd t)
         (setq current-prefix-arg meow--prefix-arg
               meow--prefix-arg nil)
@@ -430,10 +434,6 @@ try replacing the last modifier and try again."
                   this-command cmd)
             (meow--keypad-execute cmd)
             t)))
-       ((keymapp cmd)
-        (when meow-keypad-message (meow--keypad-show-message))
-        (meow--keypad-display-message)
-        nil)
        ((equal 'control (caar meow--keypad-keys))
         (setcar meow--keypad-keys (cons 'literal (cdar meow--keypad-keys)))
         (meow--keypad-try-execute))


### PR DESCRIPTION
If you start Emacs with the following configuration and type `SPC p`, an error will occur.

```elisp
(straight-use-package 'cape)
(keymap-global-set "C-c p" 'cape-prefix-map)
```

This is because `cape-prefix-map` is an autoloaded keymap.
`(commandp cmd)` returns t when `cmd` is an autoloaded keymap, but
`(call-interactively cmd)` will raise an error.

 