### PR TITLE
fix(meow-next-thing): allow no include-syntax

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -887,7 +887,9 @@ If N is negative, select to the beginning of the previous Nth thing instead."
     (meow--cancel-selection))
   (unless include-syntax
     (setq include-syntax
-          (let ((thing-include-syntax (alist-get thing meow-next-thing-include-syntax)))
+          (let ((thing-include-syntax
+                 (or (alist-get thing meow-next-thing-include-syntax)
+                     '("" ""))))
             (if (> n 0)
                 (car thing-include-syntax)
               (cadr thing-include-syntax)))))


### PR DESCRIPTION
With the addition of `meow-next-thing-include-syntax` (13733e1), `meow--fix-thing-selection-mark` expects to find an entry in this alist corresponding to `thing`. This means that when the user defines their own `thing` and sets `meow-word-thing` or `meow-symbol-thing` to use it, they also need to add a corresponding entry to this alist.

I'll admit that I don't understand why the `include-syntax` option needed to be introduced in `meow--fix-thing-selection-mark` (c0878ac). However, my own definitions of `meow-word-thing` and `meow-symbol-thing` worked fine without it. Based on that, my logic in this commit is that users shouldn't have to add to `meow-next-thing-include-syntax` unless they explicitly need the `skip-syntax-*` shrinking that was added to `meow--fix-thing-selection-mark`.