### PR TITLE
feat(commands): add meow-pop-or-unpop-to-mark

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -1562,9 +1562,25 @@ To search backward, use \\[negative-argument]."
 Before jump, a mark of current location will be created."
   (interactive)
   (meow--cancel-selection)
-  (unless (member last-command '(meow-pop-to-mark-command meow-unpop-to-mark-command))
+  (unless (member last-command '(meow-pop-to-mark-command meow-unpop-to-mark-command meow-pop-or-unpop-to-mark))
     (setq mark-ring (append mark-ring (list (point-marker)))))
   (pop-to-mark-command))
+
+(defun meow-pop-or-unpop-to-mark (arg)
+  "Call `meow-pop-to-mark' or `meow-unpop-to-mark', depending on ARG.
+
+With a negative prefix ARG, call `meow-unpop-to-mark'. Otherwise, call
+`meow-pop-to-mark.'
+
+See also `meow-pop-or-unpop-to-mark-repeat-unpop'."
+  (interactive "p")
+  (if (or (and meow-pop-or-unpop-to-mark-repeat-unpop
+               (eq last-command 'meow-unpop-to-mark))
+          (< arg 0))
+      (progn
+        (setq this-command 'meow-unpop-to-mark)
+        (meow-unpop-to-mark))
+    (meow-pop-to-mark)))
 
 (defun meow-pop-to-global-mark ()
   "Alternative command to `pop-global-mark'.

--- a/meow-var.el
+++ b/meow-var.el
@@ -200,6 +200,15 @@ the `word', `symbol' and `sexp' things, respectively.")
   :group 'meow
   :type 'boolean)
 
+(defcustom meow-pop-or-unpop-to-mark-repeat-unpop nil
+  "Non-nil means that calling `meow-pop-or-unpop-to-mark'
+after calling it with a negative argument unpops the mark again.
+
+This variable is meant to be similar to `set-mark-command-repeat-pop'."
+  :group 'meow
+  :type 'boolean)
+
+
 (defcustom meow-keypad-describe-delay
   0.5
   "The delay in seconds before popup keybinding descriptions appear."


### PR DESCRIPTION
Since `meow-search` allows us to search in the other direction using `-` (`negative-argument`), we should have similar behavior for the command that pops the mark: `-` will unpop the mark.