### PR TITLE
Add handling for meow-keypad-self-insert-undefined

### DIFF
--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -414,7 +414,8 @@ try replacing the last modifier and try again."
               meow--use-meta
               meow--use-both)
     (let* ((key-str (meow--keypad-format-keys nil))
-           (cmd (meow--keypad-lookup-key (kbd key-str))))
+           (cmd (meow--keypad-lookup-key (kbd key-str)))
+           (last-command-event (string-to-char key-str)))
       (cond
        ((keymapp cmd)
         (when meow-keypad-message (meow--keypad-show-message))
@@ -439,7 +440,9 @@ try replacing the last modifier and try again."
         (meow--keypad-try-execute))
        (t
         (setq meow--prefix-arg nil)
-        (message "%s is undefined" (meow--keypad-format-keys nil))
+        (if meow-keypad-self-insert-undefined
+            (call-interactively 'self-insert-command)
+          (message "%s is undefined" (meow--keypad-format-keys nil)))
         (meow--keypad-quit)
         t)))))
 

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -65,10 +65,8 @@
   "Lookup the command which is bound at KEYS."
   (let* ((keybind (if meow--keypad-base-keymap
 		      (lookup-key meow--keypad-base-keymap keys)
-		    (key-binding keys))))
-    (unless (and (meow--is-self-insertp keybind)
-		 (not meow-keypad-self-insert-undefined))
-	  keybind)))
+		      (key-binding keys))))
+    keybind))
 
 (defun meow--keypad-has-sub-meta-keymap-p ()
   "Check if there's a keymap belongs to Meta prefix.
@@ -414,8 +412,8 @@ try replacing the last modifier and try again."
               meow--use-meta
               meow--use-both)
     (let* ((key-str (meow--keypad-format-keys nil))
-           (cmd (meow--keypad-lookup-key (kbd key-str)))
-           (last-command-event (string-to-char key-str)))
+           (last-command-event (string-to-char key-str))
+           (cmd (meow--keypad-lookup-key (kbd key-str))))
       (cond
        ((keymapp cmd)
         (when meow-keypad-message (meow--keypad-show-message))

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -390,6 +390,7 @@ Returning DEF will result in a generated title."
   "Execute the COMMAND.
 
 If there are beacons, execute it at every beacon."
+  (setq last-command-event last-input-event)
   (if (meow--keypad-in-beacon-p)
       (cond
        ((member command '(kmacro-start-macro kmacro-start-macro-or-insert-counter))
@@ -411,11 +412,6 @@ try replacing the last modifier and try again."
   (unless (or meow--use-literal
               meow--use-meta
               meow--use-both)
-    (setq last-command-event (thread-first
-                               (car meow--keypad-keys)
-                               (meow--keypad-format-key-1)
-                               (kbd)
-                               (aref 0)))
     (let* ((key-str (meow--keypad-format-keys nil))
            (cmd (meow--keypad-lookup-key (kbd key-str))))
       (cond
@@ -506,6 +502,13 @@ command when there's one available on current key sequence."
             (setq meow--keypad-base-keymap keymap)
           (setq meow--keypad-keys (meow--parse-string-to-keypad-keys meow-keypad-leader-dispatch)))
         (push (cons 'literal key) meow--keypad-keys))))
+
+    (when meow--keypad-keys ;; Last key may be a meta modifier and won't set keypad-keys
+      (setq last-input-event (thread-first
+                               (car meow--keypad-keys)
+                               (meow--keypad-format-key-1)
+                               (kbd)
+                               (aref 0))))
 
     ;; Try execute if the input is valid.
     (if (or meow--use-literal

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -411,8 +411,12 @@ try replacing the last modifier and try again."
   (unless (or meow--use-literal
               meow--use-meta
               meow--use-both)
+    (setq last-command-event (thread-first
+                               (car meow--keypad-keys)
+                               (meow--keypad-format-key-1)
+                               (kbd)
+                               (aref 0)))
     (let* ((key-str (meow--keypad-format-keys nil))
-           (last-command-event (string-to-char key-str))
            (cmd (meow--keypad-lookup-key (kbd key-str))))
       (cond
        ((keymapp cmd)

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -441,7 +441,9 @@ try replacing the last modifier and try again."
        (t
         (setq meow--prefix-arg nil)
         (if meow-keypad-self-insert-undefined
-            (call-interactively 'self-insert-command)
+            (progn
+              (undo-boundary)
+              (meow--keypad-execute 'self-insert-command))
           (message "%s is undefined" (meow--keypad-format-keys nil)))
         (meow--keypad-quit)
         t)))))


### PR DESCRIPTION
This doesn't fully solve the problem as it doesn't get applied to beacons as expected.
May be due to setting `last-command-event` with a let so it doesn't persist?

It does make it possible to self-insert using the keypad like before.
As it sets `last-command-event` calling prefix arg from keypad also works as expected.

It is now also possible to set `meow-keypad-self-insert-undefined` to nil and bind `self-insert-command` in keypad.