### PR TITLE
add meow-keypad-capital-letter-add-ctrl 

### DIFF
--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -500,7 +500,7 @@ command when there's one available on current key sequence."
         (setq meow--use-literal t))
        (meow--keypad-keys
         (if (and meow-keypad-capital-letter-add-ctrl (equal 'control (caar (last meow--keypad-keys))))
-            (if (equal (upcase key) key)
+            (if (and (equal (upcase key) key) (= (length key) 1))
                 (push (cons 'control (downcase key)) meow--keypad-keys)
               (push (cons 'literal key) meow--keypad-keys))         
           (push (cons 'control key) meow--keypad-keys)))
@@ -512,7 +512,7 @@ command when there's one available on current key sequence."
         (if-let* ((keymap (meow--get-leader-keymap)))
             (setq meow--keypad-base-keymap keymap)
           (setq meow--keypad-keys (meow--parse-string-to-keypad-keys meow-keypad-leader-dispatch)))
-        (if (and meow-keypad-capital-letter-add-ctrl (equal (upcase key) key))
+        (if (and meow-keypad-capital-letter-add-ctrl (equal (upcase key) key) (= (length key) 1))
             (push (cons 'control (downcase key)) meow--keypad-keys)
           (push (cons 'literal key) meow--keypad-keys)))))
     ;; Try execute if the input is valid.

--- a/meow-util.el
+++ b/meow-util.el
@@ -417,9 +417,14 @@ Looks up the state in meow-replace-state-name-list"
   (if (and (integerp (event-basic-type e))
            (member 'shift (event-modifiers e)))
       (upcase (event-basic-type e))
-    (if (and meow-keypad-capital-letter-add-ctrl (string-prefix-p "C-" (key-description (vector e))) (characterp (event-basic-type e)))
+    (let ((key-des (key-description (vector e))))
+    (if (and meow-keypad-capital-letter-add-ctrl (string-prefix-p "C-" key-des) (characterp (event-basic-type e)))
         (upcase (event-basic-type e))
-      (event-basic-type e))))
+      (if (string-equal-ignore-case key-des "tab")
+        key-des
+      (event-basic-type e)
+      )
+      ))))
 
 (defun meow--ensure-visible ()
   (let ((overlays (overlays-at (1- (point))))

--- a/meow-util.el
+++ b/meow-util.el
@@ -417,7 +417,9 @@ Looks up the state in meow-replace-state-name-list"
   (if (and (integerp (event-basic-type e))
            (member 'shift (event-modifiers e)))
       (upcase (event-basic-type e))
-    (event-basic-type e)))
+    (if (and meow-keypad-capital-letter-add-ctrl (string-prefix-p "C-" (key-description (vector e))) (characterp (event-basic-type e)))
+        (upcase (event-basic-type e))
+      (event-basic-type e))))
 
 (defun meow--ensure-visible ()
   (let ((overlays (overlays-at (1- (point))))

--- a/meow-var.el
+++ b/meow-var.el
@@ -301,6 +301,12 @@ Nil stands for taking leader keymap from `meow-keymap-alist'."
   :type '(choice (string :tag "Keys")
                  (variable :tag "Keymap")
                  (const nil)))
+(defcustom meow-keypad-capital-letter-add-ctrl nil
+  "Whether to enter a capital letter, add ctrol in front of it and change 
+  the capital letter to lowercase.input uppercase letter add ctrol before. 
+  For example use `SPC x F' to execute `C-x C-f' ."
+  :group 'meow
+  :type 'boolean)
 
 (defcustom meow-keypad-meta-prefix ?m
   "The prefix represent M- in KEYPAD state."


### PR DESCRIPTION
whether to enter a capital letter, add ctrol in front of it and change
  the capital letter to lowercase.input uppercase letter add ctrol
before.
  For example use `SPC x F' to execute `C-x C-f' .