### PR TITLE
Remove H-* keys from example keybindings

### DIFF
--- a/KEYBINDING_COLEMAK.org
+++ b/KEYBINDING_COLEMAK.org
@@ -13,15 +13,13 @@ Add it to your configuration and call it before ~(meow-global-mode 1)~.
 #+begin_src emacs-lisp
   (defun meow-setup ()
     (setq meow-cheatsheet-layout meow-cheatsheet-layout-colemak)
-    (meow-motion-overwrite-define-key
+    (meow-motion-define-key
      ;; Use e to move up, n to move down.
      ;; Since special modes usually use n to move down, we only overwrite e here.
      '("e" . meow-prev)
      '("<escape>" . ignore))
     (meow-leader-define-key
      '("?" . meow-cheatsheet)
-     ;; To execute the originally e in MOTION state, use SPC e.
-     '("e" . "H-e")
      '("1" . meow-digit-argument)
      '("2" . meow-digit-argument)
      '("3" . meow-digit-argument)

--- a/KEYBINDING_DVORAK.org
+++ b/KEYBINDING_DVORAK.org
@@ -21,7 +21,7 @@ Add it to your configuration and call it before ~(meow-global-mode 1)~.
      '("0" . meow-digit-argument)
      '("/" . meow-keypad-describe-key)
      '("?" . meow-cheatsheet))
-    (meow-motion-overwrite-define-key
+    (meow-motion-define-key
      ;; custom keybinding for motion state
      '("<escape>" . ignore))
     (meow-normal-define-key

--- a/KEYBINDING_DVP.org
+++ b/KEYBINDING_DVP.org
@@ -10,7 +10,7 @@ Add it to your configuration and call it before ~(meow-global-mode 1)~.
     (setq meow-cheatsheet-layout meow-cheatsheet-layout-dvp)
     (meow-leader-define-key
      '("?" . meow-cheatsheet))
-    (meow-motion-overwrite-define-key
+    (meow-motion-define-key
      ;; custom keybinding for motion state
      '("<escape>" . ignore))
     (meow-normal-define-key

--- a/KEYBINDING_QWERTY.org
+++ b/KEYBINDING_QWERTY.org
@@ -8,14 +8,11 @@ Add it to your configuration and call it before ~(meow-global-mode 1)~.
 #+begin_src emacs-lisp
   (defun meow-setup ()
     (setq meow-cheatsheet-layout meow-cheatsheet-layout-qwerty)
-    (meow-motion-overwrite-define-key
+    (meow-motion-define-key
      '("j" . meow-next)
      '("k" . meow-prev)
      '("<escape>" . ignore))
     (meow-leader-define-key
-     ;; SPC j/k will run the original command in MOTION state.
-     '("j" . "H-j")
-     '("k" . "H-k")
      ;; Use SPC (0-9) for digit arguments.
      '("1" . meow-digit-argument)
      '("2" . meow-digit-argument)

--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -71,7 +71,7 @@ however then the original command on k/j is not accessible. To access the origin
 Here's an example: you want use ~j~ as ~next-line~ globally.
 
 #+begin_src emacs-lisp
-  (meow-motion-overwrite-define-key '("j" . next-line))
+  (meow-motion-define-key '("j" . next-line))
 #+end_src
 
 The settings we made works in all special modes.


### PR DESCRIPTION
Commit 33414b9b1cd3207002a5b94d1300f2f4947e8126 had breaking changes for configuration, and this updates the examples to match.