### PR TITLE
Update meow-tutor.el

### DIFF
--- a/meow-tutor.el
+++ b/meow-tutor.el
@@ -326,8 +326,8 @@
  * How to jump to the end of the current function quickly?
 
    1. Move cursor to the function below marked -->.
-   2. Type \\[meow-bounds-of-thing] and \"c\", then \"a\".
-
+   2. Type \\[meow-bounds-of-thing] and \"c\", then \\[meow-append].
+  
    -->
    fn count_ones(mut n: i64) -> usize {
     let mut count: usize = 0;


### PR DESCRIPTION
Fix a super minor issue in the tutor whereby one line is made more general and correct for cases when meow-append is customized. 

Mostly this is an excuse to say THANK YOU for a great package.