### PR TITLE
allow kbd-macros to also be callbacks

### DIFF
--- a/FAQ.org
+++ b/FAQ.org
@@ -21,6 +21,14 @@ Here you can map Delete character to internal Meow's delete character function.
   (setq meow--kbd-delete-char "<deletechar>")
 #+end_src
 
+The keyboard macro variables can also be assigned to defuns if you don't want them to correspond to a keyboard macro.
+
+Example:
+#+BEGIN_SRC emacs-lisp
+  (setq meow--kbd-forward-line #'next-line)
+#+END_SRC
+
+
 * Is there a integration with treesit?
 
 Yes, please check out [[https://github.com/skissue/meow-tree-sitter][meow-tree-sitter]].

--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -9,10 +9,10 @@ you have to change variable ~meow--kbd-forward-char~ to the correct value.
 Example:
 
 #+BEGIN_SRC emacs-lisp
-  (setq meow--kbd-forward-line "<right>")
+  (setq meow--kbd-forward-char "<right>")
 
   ;; or bind it to the function directly
-  (setq meow--kbd-forward-line #'forward-char)
+  (setq meow--kbd-forward-char #'forward-char)
 #+END
 
 * Keybindings Cheat Sheet

--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -6,6 +6,15 @@ Meow will find underlying commands based on keybindings. You may find abnormal b
 some default keybindings.  For example: forward-char on ~C-f~ is used by ~meow-right~. If you changed this keybinding,
 you have to change variable ~meow--kbd-forward-char~ to the correct value.
 
+Example:
+
+#+BEGIN_SRC emacs-lisp
+  (setq meow--kbd-forward-line "<right>")
+
+  ;; or bind it to the function directly
+  (setq meow--kbd-forward-line #'forward-char)
+#+END
+
 * Keybindings Cheat Sheet
 
 We have created some recommended configs for specific keyboard layouts that you can re-use for a quick setup.

--- a/meow-util.el
+++ b/meow-util.el
@@ -52,7 +52,8 @@
 (declare-function meow-keypad-start-with "meow-keypad")
 
 (defun meow--execute-kbd-macro (kbd-macro-or-defun)
-  "Execute KBD-MACRO."
+  "Execute the function bound to `KBD-MACRO-OR-DEFUN'. If `KBD-MACRO-OR-DEFUN' is a string,
+instead execute the keyboard macro it corresponds to."
   (when-let* ((ret (if (and (symbolp kbd-macro-or-defun) (fboundp kbd-macro-or-defun))
                        kbd-macro-or-defun
                      (key-binding (read-kbd-macro kbd-macro-or-defun)))))

--- a/meow-util.el
+++ b/meow-util.el
@@ -51,9 +51,11 @@
 (declare-function meow--beacon-apply-command "meow-beacon")
 (declare-function meow-keypad-start-with "meow-keypad")
 
-(defun meow--execute-kbd-macro (kbd-macro)
+(defun meow--execute-kbd-macro (kbd-macro-or-defun)
   "Execute KBD-MACRO."
-  (when-let* ((ret (key-binding (read-kbd-macro kbd-macro))))
+  (when-let* ((ret (if (and (symbolp kbd-macro-or-defun) (fboundp kbd-macro-or-defun))
+                       kbd-macro-or-defun
+                     (key-binding (read-kbd-macro kbd-macro-or-defun)))))
     (cond
      ((commandp ret)
       (setq this-command ret)
@@ -63,7 +65,7 @@
       (set-transient-map ret nil nil))
 
      ((and meow-use-keypad-when-execute-kbd (keymapp ret))
-      (meow-keypad-start-with kbd-macro)))))
+      (meow-keypad-start-with kbd-macro-or-defun)))))
 
 (defun meow-insert-mode-p ()
   "Whether insert mode is enabled."


### PR DESCRIPTION
meow forces you to bind some of the built-ins e.g. `meow-next` to keyboard macros. This makes it difficult to do rebind things like `C-n` in `meow-normal-state-keymap` because it forces you to have something bound to `next-line` in order to use `meow-next`. These changes let you additionally bind your meow kbd macros to callback functions so you can do things like:`(setq meow--kbd-forward-line #'next-line)` and then rebind `C-n`

Let me know if you'd like to keep these changes and I can document them

## Testing
to test this eval the changed buffer and eval `(setq meow--kbd-forward-line #'next-line)` then you can verify that `meow-next` works in addition to the other meow functions that use keyboard macros like `meow-prev`