### PR TITLE
Fix: Remove confusing <remap> entry from keypad display

### DIFF
--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -195,6 +195,8 @@ Argument CONTROL, non-nils stands for current input is prefixed with Control."
                  (unless (lookup-key km keys)
                    (define-key km keys (funcall meow-keypad-get-title-function def))))))
            keymap)
+          ;; Remove the remap entry added by suppress-keymap
+          (setcdr km (assq-delete-all 'remap (cdr km)))
           km)))
 
      (t


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Meow keypad displays a confusing `<remap>` entry when users press SPC to view available commands.

## Problem
When pressing SPC in Meow normal mode, the keypad shows an entry labeled `<remap>` alongside the actual commands. This entry:
- Is meaningless to users (you can't press a `<remap>` key)
- Is an implementation detail from `suppress-keymap`
- Clutters the command palette with non-actionable information

## Solution
The fix removes the remap entry from the display keymap after it's built, while preserving the actual key suppression functionality. The remap entry (which prevents character insertion) still exists in the functional keymap, it's just filtered out from what users see.

## Testing
1. Enable Meow mode
2. Press SPC in normal mode
3. Verify that no `<remap>` entry appears in the keypad display
4. Verify that pressing unmapped keys still does nothing (suppression still works)

## Technical Details
`suppress-keymap` adds a `[remap self-insert-command] -> undefined` entry to prevent character insertion. This is correct behavior for a command keymap, but the entry shouldn't be shown to users as it's not an actionable command.

The fix uses `assq-delete-all` to remove the remap symbol from the display keymap structure after building it.