### PR TITLE
Fix closing src tag in TUTORIAL.org

### DIFF
--- a/TUTORIAL.org
+++ b/TUTORIAL.org
@@ -13,7 +13,7 @@ Example:
 
   ;; or bind it to the function directly
   (setq meow--kbd-forward-char #'forward-char)
-#+END
+#+END_SRC
 
 * Keybindings Cheat Sheet
 


### PR DESCRIPTION
Should use `#+end_src` instead of `#+end` for closing tag.